### PR TITLE
DDS Config and Service deletion hotfix

### DIFF
--- a/src/Orchestrator/Deployment/DeploymentService.cs
+++ b/src/Orchestrator/Deployment/DeploymentService.cs
@@ -228,6 +228,12 @@ public class DeploymentService : IDeploymentService
                 envVars.Add(new("NETAPP_ID", instanceId.ToString()));
                 envVars.Add(new("MIDDLEWARE_ADDRESS", AppConfig.GetMiddlewareAddress()));
                 envVars.Add(new("MIDDLEWARE_REPORT_INTERVAL", 5.ToString()));
+                envVars.Add(new("ROS_DOMAIN_ID", 0.ToString()));
+                // BB 14.09.22: for the purposes of the September integration meeting
+                // to be replaced with the actual dynamically obtained address of the DDS Server
+                // that will be deployed alongside the Middleware during the startup.
+                // The address has to be updated with the address of the whole middleware.
+                envVars.Add(new("ROS_DISCOVERY_SERVER", "10.0.2.142:11811"));
 
                 container.Env = envVars;
             }

--- a/src/Orchestrator/Deployment/DeploymentService.cs
+++ b/src/Orchestrator/Deployment/DeploymentService.cs
@@ -323,8 +323,18 @@ public class DeploymentService : IDeploymentService
 
         foreach (var service in services.Items)
         {
-            var status = await k8sClient.CoreV1.DeleteNamespacedServiceAsync(service.Name(), AppConfig.K8SNamespaceName);
+            //var version = await k8sClient.Version.GetCodeWithHttpMessagesAsync();
+            try
+            {
+
+                await k8sClient.CoreV1.DeleteNamespacedServiceAsync(service.Name(), AppConfig.K8SNamespaceName);
+            }
+            catch
+            {
+                // ignored
+            }
         }
+
 
         return retVal;
     }


### PR DESCRIPTION
Fixed:
* the error during the deletion of the k8s service caused by the mismatch of the k8s server version
Added:
* Environment variables to configure the ROS Discovery server