### PR TITLE
Kubernetes version bump and package versions consolidation

### DIFF
--- a/src/CentralApi/CentralApi.csproj
+++ b/src/CentralApi/CentralApi.csproj
@@ -13,7 +13,7 @@
 
     <ItemGroup>
         <PackageReference Include="FluentValidation" Version="11.5.1" />
-        <PackageReference Include="OneOf" Version="3.0.223" />
+        <PackageReference Include="OneOf" Version="3.0.243" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
     </ItemGroup>
 

--- a/src/Common/Common.csproj
+++ b/src/Common/Common.csproj
@@ -17,13 +17,13 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="AutoMapper" Version="11.0.1" />
-	  <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="11.0.0" />
+	  <PackageReference Include="AutoMapper" Version="12.0.0" />
+	  <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.0" />
 	  <PackageReference Include="AWSSDK.Core" Version="3.3.107.40" />
 	  <PackageReference Include="AWSSDK.SecurityToken" Version="3.3.105.43" />
 	  <PackageReference Include="FluentValidation.AspNetCore" Version="11.2.2" />
 	  <PackageReference Include="Kralizek.Extensions.Configuration.AWSSecretsManager" Version="1.7.0" />
-	  <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.3" />
+	  <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.12" />
 	  <PackageReference Include="NReJSON" Version="4.0.0" />
 	  <PackageReference Include="RedisGraphDotNet.Client" Version="0.1.0-alpha" />
 	  
@@ -37,7 +37,7 @@
       <PackageReference Include="StackExchange.Redis" Version="2.6.90" />     
 	  
 	  <PackageReference Include="System.Collections" Version="4.3.0" />	
-	  <PackageReference Include="KubernetesClient" Version="8.0.12" />
+	  <PackageReference Include="KubernetesClient" Version="10.1.19" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/OcelotGateway/OcelotGateway.csproj
+++ b/src/OcelotGateway/OcelotGateway.csproj
@@ -12,17 +12,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="11.0.1" />
-    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="11.0.0" />
+    <PackageReference Include="AutoMapper" Version="12.0.0" />
+    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.3" />
     <PackageReference Include="Microsoft.IdentityModel" Version="7.0.0" />
-    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.17.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.14.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.15.0" />
     <PackageReference Include="Ocelot" Version="18.0.0" />
     <PackageReference Include="Ocelot.Cache.CacheManager" Version="18.0.0" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.17.0" />
-	<PackageReference Include="Swashbuckle.AspNetCore" Version="6.3.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.28.1" />
+	<PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
 	<PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
   </ItemGroup>
 

--- a/src/Orchestrator/Orchestrator.csproj
+++ b/src/Orchestrator/Orchestrator.csproj
@@ -28,16 +28,16 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="AutoMapper" Version="11.0.1" />
-        <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="11.0.0" />
-        <PackageReference Include="KubernetesClient" Version="8.0.12" />
+        <PackageReference Include="AutoMapper" Version="12.0.0" />
+        <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.0" />
+        <PackageReference Include="KubernetesClient" Version="10.1.19" />
         <PackageReference Include="MassTransit.Extensions.DependencyInjection" Version="7.3.1" />
         <PackageReference Include="MassTransit.RabbitMQ" Version="8.0.12" />
         <PackageReference Include="Microsoft.Extensions.ApiDescription.Client" Version="3.0.0">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.14.0" />
+        <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.15.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
         <PackageReference Include="NSwag.ApiDescription.Client" Version="13.0.5">
           <PrivateAssets>all</PrivateAssets>
@@ -47,7 +47,7 @@
         <PackageReference Include="Quartz.AspNetCore" Version="3.6.0" />
         <PackageReference Include="Quartz.Extensions.DependencyInjection" Version="3.6.0" />
         <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.3.0" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
     </ItemGroup>
 
 	<ItemGroup>

--- a/src/RedisInterface/RedisInterface.csproj
+++ b/src/RedisInterface/RedisInterface.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="NReJSON" Version="4.0.0" />
     <PackageReference Include="RedisGraphDotNet.Client" Version="0.1.0-alpha" />
     <PackageReference Include="StackExchange.Redis" Version="2.6.90" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.3.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
     <PackageReference Include="System.Collections" Version="4.3.0" />
   </ItemGroup>
 

--- a/src/ResourcePlanner/ResourcePlanner.csproj
+++ b/src/ResourcePlanner/ResourcePlanner.csproj
@@ -30,19 +30,19 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="AutoMapper" Version="11.0.1" />
-		<PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="11.0.0" />
+		<PackageReference Include="AutoMapper" Version="12.0.0" />
+		<PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.0" />
 		<PackageReference Include="Microsoft.Extensions.ApiDescription.Client" Version="3.0.0">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.14.0" />
+		<PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.15.0" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
 		<PackageReference Include="NSwag.ApiDescription.Client" Version="13.0.5">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Swashbuckle.AspNetCore" Version="6.3.0" />
+		<PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/TaskPlanner/TaskPlanner.csproj
+++ b/src/TaskPlanner/TaskPlanner.csproj
@@ -23,8 +23,8 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="AutoMapper" Version="11.0.1" />
-		<PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="11.0.0" />
+		<PackageReference Include="AutoMapper" Version="12.0.0" />
+		<PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.0" />
 		<PackageReference Include="FluentValidation" Version="11.5.1" />
 		<PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.5.1" />
 		<PackageReference Include="MassTransit.Extensions.DependencyInjection" Version="7.3.1" />
@@ -33,7 +33,7 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.14.0" />
+		<PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.15.0" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
 		<PackageReference Include="NSwag.ApiDescription.Client" Version="13.0.5">
 			<PrivateAssets>all</PrivateAssets>
@@ -41,7 +41,7 @@
 		</PackageReference>
 		<PackageReference Include="OneOf" Version="3.0.243" />
 		<PackageReference Include="RabbitMQ.Client" Version="6.4.0" />
-		<PackageReference Include="Swashbuckle.AspNetCore" Version="6.3.0" />
+		<PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/test/Common.Tests.Unit/Common.Tests.Unit.csproj
+++ b/test/Common.Tests.Unit/Common.Tests.Unit.csproj
@@ -9,11 +9,11 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="FluentAssertions" Version="6.9.0" />
-		<PackageReference Include="NSubstitute" Version="4.4.0" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-		<PackageReference Include="xunit" Version="2.4.1" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+		<PackageReference Include="FluentAssertions" Version="6.10.0" />
+		<PackageReference Include="NSubstitute" Version="5.0.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+		<PackageReference Include="xunit" Version="2.4.2" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>

--- a/test/DataAccess.Tests.Unit/DataAccess.Tests.Unit.csproj
+++ b/test/DataAccess.Tests.Unit/DataAccess.Tests.Unit.csproj
@@ -9,9 +9,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.9.0" />
+        <PackageReference Include="FluentAssertions" Version="6.10.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
-        <PackageReference Include="NSubstitute" Version="4.4.0" />
+        <PackageReference Include="NSubstitute" Version="5.0.0" />
         <PackageReference Include="xunit" Version="2.4.2" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/Orchestrator.Tests.Unit/Orchestrator.Tests.Unit.csproj
+++ b/test/Orchestrator.Tests.Unit/Orchestrator.Tests.Unit.csproj
@@ -8,15 +8,15 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="FluentAssertions" Version="6.9.0" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-		<PackageReference Include="NSubstitute" Version="4.4.0" />
-		<PackageReference Include="xunit" Version="2.4.1" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+		<PackageReference Include="FluentAssertions" Version="6.10.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+		<PackageReference Include="NSubstitute" Version="5.0.0" />
+		<PackageReference Include="xunit" Version="2.4.2" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
-		<PackageReference Include="coverlet.collector" Version="3.1.0">
+		<PackageReference Include="coverlet.collector" Version="3.1.2">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>

--- a/test/RedisInterface.Sdk.Tests.Integration/RedisInterface.Sdk.Tests.Integration.csproj
+++ b/test/RedisInterface.Sdk.Tests.Integration/RedisInterface.Sdk.Tests.Integration.csproj
@@ -12,11 +12,11 @@
         <PackageReference Include="Bogus" Version="34.0.2" />
         <PackageReference Include="FluentAssertions" Version="6.10.0" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.15" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
         <PackageReference Include="NSubstitute" Version="5.0.0" />
         <PackageReference Include="Testcontainers" Version="3.0.0" />
-        <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+        <PackageReference Include="xunit" Version="2.4.2" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>


### PR DESCRIPTION
# Kubernetes version bump and package versions consolidation

Currently supported Kubernetes API v1.24 has EoL on 2023-07-28. There is a need to update to the more up-to-date version. 
This is done by upgrading the `KubernetesClient` NuGet package.
On top of this, it is a good moment to consolidate different versions of the same package across the solution
From now on, the middleware will support versions ranging from `v1.24` to `v1.28` (future release).

Fixes #147 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## What has been changed?

- Feature: Update `KubernetesClient` package version to 
- Fix: Inconsistent package versions in the solution
- Doc: Need to add supported versions of the Kubernetes in the docs. Will be done by #116 

# How Has This Been Tested?

1. Solution compiles without new warnings
2. NetApp deployment tested with the local Kubernetes version `v1.26`

# Checklist:

- [ ] My code follows the style guidelines of this project - BB: Not applicable, o code changes
- [ ] I have performed a self-review of my code - BB: Not applicable, o code changes
- [ ] I have commented my code, particularly in hard-to-understand areas - BB: Not applicable, o code changes
- [ ] I have made corresponding changes to the documentation - BB: Not applicable, o code changes
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works - BB: Not applicable, o code changes
- [ ] New and existing unit tests pass locally with my changes - BB: Not applicable, o code changes