### PR TITLE
Fixed ImportTask endpoint bugs

### DIFF
--- a/src/RedisInterface/RedisInterface.csproj
+++ b/src/RedisInterface/RedisInterface.csproj
@@ -9,7 +9,6 @@
 	<RootNamespace>Middleware.RedisInterface</RootNamespace>
     <DockerfileContext>..\..</DockerfileContext>
     <DockerComposeProjectPath>..\..\docker-compose.dcproj</DockerComposeProjectPath>
-    <DebugType>full</DebugType>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">


### PR DESCRIPTION
# Description

The **ImportTask** endpoint had a few bugs that were not in accordance with the proposed functionality and could have lead to inconsistent semantic planning and incorrect deployment of the Network Applications. 

Fixes #144 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## What has been changed?

- Fix: The existing models will not be overridden 
- Fix: Skip creating entities when only the Id of the entity is given
- Fix: Allow reuse of the existing DB objects in creating a new plan (when the Id of an object is given)
- Feature: When the existing Id is given, the new plan should be able to utilize the existing entity with its relations.

# How Has This Been Tested?

The following tests have been performed:

1. Imported completely new task definition with action sequence
2. Created new task definition and reused previously created action sequence and relations 
3. Created new task definition with new action sequence and reused previously created action sequence and relations

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes