### PR TITLE
fix: updated policy to limit to allow change only policy "priority" and "isactive"

### DIFF
--- a/src/RedisInterface/Controllers/PolicyController.cs
+++ b/src/RedisInterface/Controllers/PolicyController.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Middleware.Common.Attributes;
 using Middleware.Common.Responses;
@@ -197,14 +198,19 @@ namespace Middleware.RedisInterface.Controllers
         {
             try
             {
-                var model = request.ToPolicy();
+                var model = request.ToLimitedPolicy();
                 var exists = await _policyRepository.GetByIdAsync(model.Id);
                 if (exists == null)
                 {
                     return NotFound(new ApiResponse((int)HttpStatusCode.NotFound, "Object to be updated was not found."));
                 }
-                await _policyRepository.UpdateAsync(model);
-                var response = model.ToPolicyResponse();
+
+                exists.IsActive = model.IsActive;
+                exists.Priority = model.Priority;
+                exists.Timestamp = DateTime.Now;
+
+                await _policyRepository.UpdateAsync(exists);
+                var response = exists.ToPolicyResponse();
                 return Ok(response);
             }
             catch (Exception ex) 

--- a/src/RedisInterface/Controllers/PolicyController.cs
+++ b/src/RedisInterface/Controllers/PolicyController.cs
@@ -207,7 +207,7 @@ namespace Middleware.RedisInterface.Controllers
 
                 exists.IsActive = model.IsActive;
                 exists.Priority = model.Priority;
-                exists.Timestamp = DateTime.Now;
+                exists.Timestamp = DateTime.UtcNow;
 
                 await _policyRepository.UpdateAsync(exists);
                 var response = exists.ToPolicyResponse();

--- a/src/RedisInterface/Mappings/ApiContractToDomainMapper.cs
+++ b/src/RedisInterface/Mappings/ApiContractToDomainMapper.cs
@@ -105,6 +105,15 @@ public static class ApiContractToDomainMapper
             Timestamp = x.Policy.LastTimeUpdated
         };
     }
+    public static PolicyModel ToLimitedPolicy(this UpdatePolicyRequest x)
+    {
+        return new()
+        {
+            Id = x.Id,
+            IsActive = x.Policy.IsActive,
+            Priority = Enum.Parse<Priority>(x.Policy.Priority)
+        };
+    }
 
     public static RobotModel ToRobot(this UpdateRobotRequest x)
     {

--- a/src/RedisInterface/Properties/launchSettings.json
+++ b/src/RedisInterface/Properties/launchSettings.json
@@ -1,13 +1,4 @@
 {
-  "$schema": "https://json.schemastore.org/launchsettings.json",
-  "iisSettings": {
-    "windowsAuthentication": false,
-    "anonymousAuthentication": true,
-    "iisExpress": {
-      "applicationUrl": "http://localhost:18630",
-      "sslPort": 44327
-    }
-  },
   "profiles": {
     "RedisInterface": {
       "commandName": "Project",
@@ -33,6 +24,25 @@
       "launchUrl": "{Scheme}://{ServiceHost}:{ServicePort}/swagger",
       "publishAllPorts": true,
       "useSSL": true
+    },
+    "WSL": {
+      "commandName": "WSL2",
+      "launchBrowser": true,
+      "launchUrl": "https://localhost:3091/swagger",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "ASPNETCORE_URLS": "https://localhost:3091;http://localhost:4091"
+      },
+      "distributionName": ""
+    }
+  },
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:18630",
+      "sslPort": 44327
     }
   }
 }

--- a/src/RedisInterface/Validation/PolicyRequestValidator.cs
+++ b/src/RedisInterface/Validation/PolicyRequestValidator.cs
@@ -28,7 +28,7 @@ public class PolicyRequestValidator : AbstractValidator<PolicyRequest>
             .NotNull().IsEnumName(typeof(Priority), caseSensitive: false)
             .WithMessage(x =>
                 $"{x.Priority} is not a valid Policy Priority name. " +
-                $"Valid options are: {string.Join(", ", Enum.GetNames<PolicyType>())}");
+                $"Valid options are: {string.Join(", ", Enum.GetNames<Priority>())}");
         //TODO: add validation if the policy can be active when it is added or activated
     }
 }

--- a/src/RedisInterface/Validation/UpdatePolicyRequestValidator.cs
+++ b/src/RedisInterface/Validation/UpdatePolicyRequestValidator.cs
@@ -1,0 +1,14 @@
+﻿using FluentValidation;
+using Middleware.Models.Enums;
+using Middleware.RedisInterface.Contracts.Requests;
+using Middleware.RedisInterface.Requests;
+
+namespace Middleware.RedisInterface.Validation;
+
+public class UpdatePolicyRequestValidator : AbstractValidator<UpdatePolicyRequest>
+{
+    public UpdatePolicyRequestValidator(PolicyRequestValidator prv)
+    {
+        RuleFor(x => x.Policy).SetValidator(prv);        
+    }
+}


### PR DESCRIPTION

# Description
Policies had large set of properties allowed to be configurable by the end-use. Now end-user can  update only two properties in the policy definition:
IsActive,
Priority

Fixes # End-user can  update only two properties in the policy definition: IsActive, Priority.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## What has been changed?

- Fix: End-user can  update only two properties in the policy definition:
IsActive,
Priority

Updated validation for these property.

# How Has This Been Tested?

- [x] Test A: The values of parameters "isActive" and "Priority" was set to nonvalid => result: in response apropriate error message was displayed.
- [x] Test B: The value of parameter "isActive" was deleted; => result: the default value was set and updated.
- [x] Test C: The other values of parameters was changed/omited; => result: the update did not make any changes on other parmeters.
- [x] Test D: The "isActive" and "priority" was updated with valid values; => result: updated successfuly only required parameters.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings