### PR TITLE
fix: fixed resource reuse when no heartbeat is detected

### DIFF
--- a/src/ResourcePlanner/ApiReference/ApiClientBuilder.cs
+++ b/src/ResourcePlanner/ApiReference/ApiClientBuilder.cs
@@ -6,19 +6,21 @@ namespace Middleware.ResourcePlanner.ApiReference;
 
 public class ApiClientBuilder : IApiClientBuilder
 {
-    private readonly IHttpClientFactory _httpClientFactory;
     private readonly IEnvironment _env;
+    private readonly IHttpClientFactory _httpClientFactory;
 
     public ApiClientBuilder(IHttpClientFactory httpClientFactory, IEnvironment env)
     {
         _httpClientFactory = httpClientFactory;
         _env = env;
     }
+
     public OrchestratorApiClient CreateOrchestratorApiClient()
     {
         var address = _env.GetEnvVariable("ORCHESTRATOR_API_SERVICE_HOST") ??
-                      throw new ArgumentNullException("ORCHESTRATOR_API_SERVICE_HOST", "ORCHESTRATOR_API_SERVICE_HOST environment variable not specified");
+                      throw new ArgumentNullException("ORCHESTRATOR_API_SERVICE_HOST",
+                          "ORCHESTRATOR_API_SERVICE_HOST environment variable not specified");
         var client = _httpClientFactory.CreateClient(AppConfig.OrchestratorApiClientName);
-        return new OrchestratorApiClient($"{address}", client);
+        return new($"http://{address}", client);
     }
 }

--- a/src/TaskPlanner/Config/AutoMapperConfig.cs
+++ b/src/TaskPlanner/Config/AutoMapperConfig.cs
@@ -33,6 +33,7 @@ public static class AutoMapperConfig
             cfg.CreateMap<KeyValuePair, ResourcePlanner.KeyValuePair>().ReverseMap();
             cfg.CreateMap<RelationModel, ResourcePlanner.RelationModel>().ReverseMap();
             cfg.CreateMap<GraphEntityModel, ResourcePlanner.GraphEntityModel>().ReverseMap();
+            cfg.CreateMap<ContainerImageModel, ResourcePlanner.ContainerImageModel>().ReverseMap();
         });
         return services;
     }


### PR DESCRIPTION
# Description

When no heartbeat from the NetApp is sent, the resource reuse found no applications that could be reused. This fix enables resource reuse based only on the availability of reused NetApp, and no heartbeat is needed. 

Fixes #199 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## What has been changed?

1. Bugfix: resource reuse when no heartbeat is detected

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes