### PR TITLE
feat: new endpoints for dashboard

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -11,6 +11,7 @@ services:
       - REDIS_HOSTNAME=${REDIS_HOSTNAME}
       - REDIS_PORT=${REDIS_PORT}
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
+      - CENTRAL_API_HOSTNAME=central.api
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
       - Middleware__Organization=5G-ERA-DEV
       - Middleware__InstanceName=MiddlewareBB

--- a/src/CentralApi.Sdk/CentralApiClient.cs
+++ b/src/CentralApi.Sdk/CentralApiClient.cs
@@ -8,26 +8,38 @@ using Middleware.CentralApi.Sdk.Options;
 namespace Middleware.CentralApi.Sdk;
 
 /// <summary>
-/// Central API Middleware client
+///     Central API Middleware client
 /// </summary>
 public class CentralApiClient : ICentralApiClient
 {
-    private readonly ICentralApi _api;
     private readonly LocationApiAccessOptions _accessOptions;
+    private readonly ICentralApi _api;
     private readonly ILogger<CentralApiClient> _logger;
 
-    public CentralApiClient(ICentralApi api, IOptions<LocationApiAccessOptions> accessOptions, ILogger<CentralApiClient> logger)
+    public CentralApiClient(ICentralApi api, IOptions<LocationApiAccessOptions> accessOptions,
+        ILogger<CentralApiClient> logger)
     {
         _api = api;
         _accessOptions = accessOptions.Value;
         _logger = logger;
     }
+
     public async Task<LocationsResponse?> GetAvailableLocations()
     {
         _logger.LogDebug("Entered GetAvailableLocations");
-        
+
         var org = _accessOptions.Organization;
         var response = await _api.GetAvailableLocations(org);
+
+        return response.IsSuccessStatusCode ? response.Content : null;
+    }
+
+    /// <inheritdoc />
+    public async Task<LocationsResponse?> GetAvailableLocations(string orgName)
+    {
+        _logger.LogDebug("Entered GetAvailableLocations(string orgName)");
+
+        var response = await _api.GetAvailableLocations(orgName);
 
         return response.IsSuccessStatusCode ? response.Content : null;
     }

--- a/src/CentralApi.Sdk/ICentralApiClient.cs
+++ b/src/CentralApi.Sdk/ICentralApiClient.cs
@@ -6,20 +6,26 @@ namespace Middleware.CentralApi.Sdk;
 public interface ICentralApiClient
 {
     /// <summary>
-    /// Gets all available (online) Middleware locations  
+    ///     Gets all available (online) Middleware locations
     /// </summary>
     /// <returns></returns>
     Task<LocationsResponse?> GetAvailableLocations();
 
     /// <summary>
-    /// Sets specified location available (online) to be communicated to 
+    ///     Gets all available (online) Middleware locations for the specified Organization
+    /// </summary>
+    /// <returns></returns>
+    Task<LocationsResponse?> GetAvailableLocations(string orgName);
+
+    /// <summary>
+    ///     Sets specified location available (online) to be communicated to
     /// </summary>
     /// <param name="request"></param>
     /// <returns></returns>
     Task<LocationResponse?> RegisterLocation(RegisterRequest request);
 
     /// <summary>
-    /// Sets specified location unavailable (offline)
+    ///     Sets specified location unavailable (offline)
     /// </summary>
     /// <param name="request"></param>
     /// <returns></returns>

--- a/src/DataConverter/Program.cs
+++ b/src/DataConverter/Program.cs
@@ -4,36 +4,35 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Middleware.Common.Config;
 using Middleware.DataAccess.Repositories;
 using Middleware.DataAccess.Repositories.Redis;
-using Middleware.Models.Domain;
-using Middleware.RedisInterface.Contracts.Responses;
-using Middleware.RedisInterface.Services;
 using Redis.OM;
 using Redis.OM.Contracts;
 using RedisGraphDotNet.Client;
+using Serilog;
 using StackExchange.Redis;
 
-ConfigurationManager configurationManager = new ConfigurationManager();
+var configurationManager = new ConfigurationManager();
 configurationManager.AddUserSecrets(Assembly.GetAssembly(typeof(Program)));
 var redisConfig = configurationManager.GetSection(RedisConfig.ConfigName).Get<RedisConfig>();
 
 
-ConnectionMultiplexer multiplexer = ConnectionMultiplexer.Connect(
+var multiplexer = ConnectionMultiplexer.Connect(
     redisConfig.HostName,
-    (c) => { c.Password = redisConfig.Password; });
+    c => { c.Password = redisConfig.Password; });
 IRedisGraphClient redisGraphClient = new RedisGraphClient(multiplexer);
 
 //For the redis-cluster master node, port 6380 should be used, using port 6379 will point to the replicas of the redis-cluster
-ConnectionMultiplexer clusterMultiplexer =
+var clusterMultiplexer =
     ConnectionMultiplexer.Connect($"{redisConfig.ClusterHostname}:6380", c => c.Password = redisConfig.Password);
 IRedisConnectionProvider clusterConnectionProvider = new RedisConnectionProvider(clusterMultiplexer);
 
 IRedisGraphClient clusterGraphClient = new RedisGraphClient(clusterMultiplexer);
 
 #region Robot
+
 Console.WriteLine("Writing Robots...");
 var robotRepository = new RobotRepository(multiplexer, redisGraphClient, new NullLogger<RobotRepository>());
 var clusterRobotRepository =
-    new RedisRobotRepository(clusterConnectionProvider, clusterGraphClient, Serilog.Log.Logger);
+    new RedisRobotRepository(clusterConnectionProvider, clusterGraphClient, Log.Logger);
 
 var robots = await robotRepository.GetAllAsync();
 
@@ -41,13 +40,15 @@ foreach (var robot in robots)
 {
     await clusterRobotRepository.AddAsync(robot);
 }
+
 #endregion
 
 #region action
+
 Console.WriteLine("Writing Actions...");
 var actionRepository = new ActionRepository(multiplexer, redisGraphClient, new NullLogger<ActionRepository>());
 var clusterActionRepository =
-    new RedisActionRepository(clusterConnectionProvider, clusterGraphClient, Serilog.Log.Logger);
+    new RedisActionRepository(clusterConnectionProvider, clusterGraphClient, Log.Logger);
 
 var actions = await actionRepository.GetAllAsync();
 
@@ -60,10 +61,11 @@ foreach (var action in actions)
 
 
 #region cloud
+
 Console.WriteLine("Writing Clouds...");
 var cloudRepository = new CloudRepository(multiplexer, redisGraphClient, new NullLogger<CloudRepository>());
 var redisCloudRepository =
-    new RedisCloudRepository(clusterConnectionProvider, clusterGraphClient, Serilog.Log.Logger);
+    new RedisCloudRepository(clusterConnectionProvider, clusterGraphClient, Log.Logger);
 
 var clouds = await cloudRepository.GetAllAsync();
 
@@ -76,10 +78,11 @@ foreach (var cloud in clouds)
 
 
 #region instance
+
 Console.WriteLine("Writing Instances...");
 var instanceRepository = new InstanceRepository(multiplexer, redisGraphClient, new NullLogger<InstanceRepository>());
 var redisInstanceRepository =
-    new RedisInstanceRepository(clusterConnectionProvider, clusterGraphClient, Serilog.Log.Logger);
+    new RedisInstanceRepository(clusterConnectionProvider, clusterGraphClient, Log.Logger);
 
 var instances = await instanceRepository.GetAllAsync();
 
@@ -91,10 +94,13 @@ foreach (var instance in instances)
 #endregion
 
 #region continerImage
+
 Console.WriteLine("Writing Container images...");
-var containerImageRepository = new ContainerImageRepository(instanceRepository, multiplexer, redisGraphClient, new NullLogger<ContainerImageRepository>());
+var containerImageRepository = new ContainerImageRepository(instanceRepository, multiplexer, redisGraphClient,
+    new NullLogger<ContainerImageRepository>());
 var redisContainerImageRepository =
-    new RedisContainerImageRepository(redisInstanceRepository, clusterConnectionProvider, clusterGraphClient, Serilog.Log.Logger);
+    new RedisContainerImageRepository(redisInstanceRepository, clusterConnectionProvider, clusterGraphClient,
+        Log.Logger);
 
 var containers = await containerImageRepository.GetAllAsync();
 
@@ -106,10 +112,11 @@ foreach (var container in containers)
 #endregion
 
 #region Edge
+
 Console.WriteLine("Writing Edges...");
 var edgeRepository = new EdgeRepository(multiplexer, redisGraphClient, new NullLogger<EdgeRepository>());
 var redisEdgeRepository =
-    new RedisEdgeRepository(clusterConnectionProvider, clusterGraphClient, Serilog.Log.Logger);
+    new RedisEdgeRepository(clusterConnectionProvider, clusterGraphClient, Log.Logger);
 
 var edges = await edgeRepository.GetAllAsync();
 
@@ -122,10 +129,11 @@ foreach (var edge in edges)
 
 
 #region Users
+
 Console.WriteLine("Writing Users...");
 var userRepository = new UserRepository(multiplexer, redisGraphClient, new NullLogger<UserRepository>());
 var redisUserRepository =
-    new RedisUserRepository(clusterConnectionProvider, clusterGraphClient, Serilog.Log.Logger);
+    new RedisUserRepository(clusterConnectionProvider, clusterGraphClient, Log.Logger);
 
 var users = await userRepository.GetAllAsync();
 
@@ -138,10 +146,11 @@ foreach (var user in users)
 
 
 #region Policy
+
 Console.WriteLine("Writing Policies...");
 var policyRepository = new PolicyRepository(multiplexer, redisGraphClient, new NullLogger<PolicyRepository>());
 var redisPolicyRepository =
-    new RedisPolicyRepository(clusterConnectionProvider, clusterGraphClient, Serilog.Log.Logger);
+    new RedisPolicyRepository(clusterConnectionProvider, clusterGraphClient, Log.Logger);
 
 var policies = await policyRepository.GetAllAsync();
 
@@ -153,12 +162,12 @@ foreach (var policy in policies)
 #endregion
 
 
-
 #region Task
+
 Console.WriteLine("Writing Tasks...");
 var taskRepository = new TaskRepository(multiplexer, redisGraphClient, new NullLogger<TaskRepository>());
 var redisTaskRepository =
-    new RedisTaskRepository(clusterConnectionProvider, clusterGraphClient, Serilog.Log.Logger);
+    new RedisTaskRepository(clusterConnectionProvider, clusterGraphClient, Log.Logger);
 
 var tasks = await taskRepository.GetAllAsync();
 
@@ -171,10 +180,12 @@ foreach (var task in tasks)
 
 
 #region ActionPlan
+
 Console.WriteLine("Writing ActionPlans...");
-var actionPlanRepository = new ActionPlanRepository(multiplexer, redisGraphClient, new NullLogger<ActionPlanRepository>());
+var actionPlanRepository =
+    new ActionPlanRepository(multiplexer, redisGraphClient, new NullLogger<ActionPlanRepository>());
 var redisActionPlanRepository =
-    new RedisActionPlanRepository(clusterConnectionProvider, clusterGraphClient, Serilog.Log.Logger);
+    new RedisActionPlanRepository(clusterConnectionProvider, clusterGraphClient, Log.Logger);
 
 var actionPlans = await actionPlanRepository.GetAllAsync();
 
@@ -182,36 +193,36 @@ foreach (var actionPlan in actionPlans)
 {
     actionPlan.LastStatusChange = DateTime.Now;
     actionPlan.TaskStartedAt = DateTime.Now.AddDays(-1);
-    actionPlan.ActionSequence.ForEach(a=>a.Services.ForEach(i=>i.OnboardedTime = DateTime.Today.AddDays(-10)));
+    actionPlan.ActionSequence.ForEach(a => a.Services.ForEach(i => i.OnboardedTime = DateTime.Today.AddDays(-10)));
     await redisActionPlanRepository.AddAsync(actionPlan);
 }
 
 #endregion
 
-#region relations
-Console.WriteLine("Writing Relations...");
+//#region relations
+//Console.WriteLine("Writing Relations...");
 
-var dashboardService = new DashboardService(robotRepository, taskRepository, actionPlanRepository, edgeRepository,
-    cloudRepository, instanceRepository, actionRepository);
+//var dashboardService = new DashboardService(robotRepository, taskRepository, actionPlanRepository, edgeRepository,
+//    cloudRepository, instanceRepository, actionRepository, new CentralApiClient());
 
-var relations = await dashboardService.GetAllRelationModelsAsync();
+//var relations = await dashboardService.GetAllRelationModelsAsync();
 
-var entities = relations.Entities;
-//var types = entities.Select(x => x.Type).Distinct().ToList();
+//var entities = relations.Entities;
+////var types = entities.Select(x => x.Type).Distinct().ToList();
 
-var hashRelations = relations.Relations.ToHashSet(new SimpleRelationComparer());
-foreach (var relation in hashRelations)
-{
-    var initiates = entities.FirstOrDefault(e => e.Id == relation.OriginatingId);
-    var points = entities.FirstOrDefault(e => e.Id == relation.PointsToId);
-    if (initiates is null || points is null)
-    {
-        continue;
-    }
-    var fullRelation = new RelationModel(initiates, points, relation.RelationName);
-    await redisActionPlanRepository.AddRelationAsync(fullRelation);
-}
-#endregion
+//var hashRelations = relations.Relations.ToHashSet(new SimpleRelationComparer());
+//foreach (var relation in hashRelations)
+//{
+//    var initiates = entities.FirstOrDefault(e => e.Id == relation.OriginatingId);
+//    var points = entities.FirstOrDefault(e => e.Id == relation.PointsToId);
+//    if (initiates is null || points is null)
+//    {
+//        continue;
+//    }
+//    var fullRelation = new RelationModel(initiates, points, relation.RelationName);
+//    await redisActionPlanRepository.AddRelationAsync(fullRelation);
+//}
+//#endregion
 
 Console.WriteLine("The data conversion process has finished. Press any key to close.");
 Console.ReadLine();

--- a/src/Orchestrator/Controllers/StatusController.cs
+++ b/src/Orchestrator/Controllers/StatusController.cs
@@ -4,6 +4,7 @@ using Middleware.Common.Responses;
 using Middleware.DataAccess.Repositories.Abstract;
 using Middleware.Models.Domain;
 using Middleware.Orchestrator.Heartbeat;
+using Middleware.Orchestrator.Models.Responses;
 using Middleware.RedisInterface.Sdk;
 
 namespace Middleware.Orchestrator.Controllers;
@@ -39,7 +40,7 @@ public class StatusController : Controller
     /// <returns> the list of RobotStatusModel entities </returns>
     [HttpGet]
     [Route("robot", Name = "RobotStatusGetAll")]
-    [ProducesResponseType(typeof(RobotStatusModel), (int)HttpStatusCode.OK)]
+    [ProducesResponseType(typeof(GetRobotStatusesResponse), (int)HttpStatusCode.OK)]
     [ProducesResponseType(typeof(ApiResponse), (int)HttpStatusCode.BadRequest)]
     [ProducesResponseType(typeof(ApiResponse), (int)HttpStatusCode.NotFound)]
     [ProducesResponseType(typeof(ApiResponse), (int)HttpStatusCode.InternalServerError)]
@@ -54,7 +55,11 @@ public class StatusController : Controller
                     "No robot statuses were found."));
             }
 
-            return Ok(status);
+            var resp = new GetRobotStatusesResponse
+            {
+                Robots = status
+            };
+            return Ok(resp);
         }
         catch (Exception ex)
         {
@@ -136,7 +141,7 @@ public class StatusController : Controller
     /// <returns> the list of RobotStatusModel entities </returns>
     [HttpGet]
     [Route("netapp", Name = "NetAppStatuses")]
-    [ProducesResponseType(typeof(NetAppStatusModel), (int)HttpStatusCode.OK)]
+    [ProducesResponseType(typeof(GetNetAppStatusesResponse), (int)HttpStatusCode.OK)]
     [ProducesResponseType(typeof(ApiResponse), (int)HttpStatusCode.BadRequest)]
     [ProducesResponseType(typeof(ApiResponse), (int)HttpStatusCode.NotFound)]
     [ProducesResponseType(typeof(ApiResponse), (int)HttpStatusCode.InternalServerError)]
@@ -151,7 +156,11 @@ public class StatusController : Controller
                     "No NetApp statuses were found."));
             }
 
-            return Ok(status);
+            var resp = new GetNetAppStatusesResponse
+            {
+                NetApps = status
+            };
+            return Ok(resp);
         }
         catch (Exception ex)
         {

--- a/src/Orchestrator/Controllers/StatusController.cs
+++ b/src/Orchestrator/Controllers/StatusController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Mvc;
 using Middleware.Common.Responses;
 using Middleware.DataAccess.Repositories.Abstract;
 using Middleware.Models.Domain;
+using Middleware.Orchestrator.Heartbeat;
 using Middleware.RedisInterface.Sdk;
 
 namespace Middleware.Orchestrator.Controllers;
@@ -11,6 +12,7 @@ namespace Middleware.Orchestrator.Controllers;
 [ApiController]
 public class StatusController : Controller
 {
+    private readonly IHeartbeatService _heartbeatService;
     private readonly ILogger _logger;
     private readonly INetAppStatusRepository _netAppStatusRepository;
     private readonly IRedisInterfaceClient _redisInterfaceClient;
@@ -19,13 +21,47 @@ public class StatusController : Controller
     public StatusController(INetAppStatusRepository netAppStatusRepository,
         IRobotStatusRepository robotStatusRepository,
         ILogger<StatusController> logger,
-        IRedisInterfaceClient redisInterfaceClient
+        IRedisInterfaceClient redisInterfaceClient,
+        IHeartbeatService heartbeatService
     )
     {
         _netAppStatusRepository = netAppStatusRepository;
         _robotStatusRepository = robotStatusRepository;
         _logger = logger;
         _redisInterfaceClient = redisInterfaceClient;
+        _heartbeatService = heartbeatService;
+    }
+
+
+    /// <summary>
+    ///     Get the robot status
+    /// </summary>
+    /// <returns> the list of RobotStatusModel entities </returns>
+    [HttpGet]
+    [Route("robot", Name = "RobotStatusGetAll")]
+    [ProducesResponseType(typeof(RobotStatusModel), (int)HttpStatusCode.OK)]
+    [ProducesResponseType(typeof(ApiResponse), (int)HttpStatusCode.BadRequest)]
+    [ProducesResponseType(typeof(ApiResponse), (int)HttpStatusCode.NotFound)]
+    [ProducesResponseType(typeof(ApiResponse), (int)HttpStatusCode.InternalServerError)]
+    public async Task<ActionResult<RobotStatusModel>> GetRobotStatusesAsync(bool generateFakeData = false)
+    {
+        try
+        {
+            var status = await _heartbeatService.GetAllRobotStatusesAsync(generateFakeData);
+            if (status is null)
+            {
+                return NotFound(new ApiResponse((int)HttpStatusCode.NotFound,
+                    "Status for the specified robot was not found."));
+            }
+
+            return Ok(status);
+        }
+        catch (Exception ex)
+        {
+            var statusCode = (int)HttpStatusCode.InternalServerError;
+            _logger.LogError(ex, "An error occurred:");
+            return StatusCode(statusCode, new ApiResponse(statusCode, $"An error has occurred: {ex.Message}"));
+        }
     }
 
     /// <summary>
@@ -33,12 +69,12 @@ public class StatusController : Controller
     /// </summary>
     /// <returns> the list of RobotStatusModel entities </returns>
     [HttpGet]
-    [Route("robot", Name = "RobotStatusGetById")]
+    [Route("robot/{id}", Name = "RobotStatusGetById")]
     [ProducesResponseType(typeof(RobotStatusModel), (int)HttpStatusCode.OK)]
     [ProducesResponseType(typeof(ApiResponse), (int)HttpStatusCode.BadRequest)]
     [ProducesResponseType(typeof(ApiResponse), (int)HttpStatusCode.NotFound)]
     [ProducesResponseType(typeof(ApiResponse), (int)HttpStatusCode.InternalServerError)]
-    public async Task<ActionResult<RobotStatusModel>> GetRobotStatusByIdAsync(Guid id)
+    public async Task<ActionResult<RobotStatusModel>> GetRobotStatusByIdAsync(Guid id, bool generateFakeData = false)
     {
         if (id == Guid.Empty)
         {
@@ -48,11 +84,13 @@ public class StatusController : Controller
 
         try
         {
-            //TODO: put behind service
-            var status = await _robotStatusRepository.GetByIdAsync(id);
+            var status = await _heartbeatService.GetRobotStatusByIdAsync(id, generateFakeData);
             if (status is null)
+            {
                 return NotFound(new ApiResponse((int)HttpStatusCode.NotFound,
                     "Status for the specified robot was not found."));
+            }
+
             return Ok(status);
         }
         catch (Exception ex)
@@ -97,12 +135,43 @@ public class StatusController : Controller
     /// </summary>
     /// <returns> the list of RobotStatusModel entities </returns>
     [HttpGet]
-    [Route("netapp", Name = "NetAppStatusGetById")]
+    [Route("netapp", Name = "NetAppStatuses")]
     [ProducesResponseType(typeof(NetAppStatusModel), (int)HttpStatusCode.OK)]
     [ProducesResponseType(typeof(ApiResponse), (int)HttpStatusCode.BadRequest)]
     [ProducesResponseType(typeof(ApiResponse), (int)HttpStatusCode.NotFound)]
     [ProducesResponseType(typeof(ApiResponse), (int)HttpStatusCode.InternalServerError)]
-    public async Task<ActionResult<NetAppStatusModel>> GetNetAppStatusByIdAsync(Guid id)
+    public async Task<ActionResult<NetAppStatusModel>> GetNetAppStatusesAsync(bool generateFakeData = false)
+    {
+        try
+        {
+            var status = await _heartbeatService.GetAllAppStatusesAsync(generateFakeData);
+            if (status is null)
+            {
+                return NotFound(new ApiResponse((int)HttpStatusCode.NotFound,
+                    "Status for the specified robot was not found."));
+            }
+
+            return Ok(status);
+        }
+        catch (Exception ex)
+        {
+            var statusCode = (int)HttpStatusCode.InternalServerError;
+            _logger.LogError(ex, "An error occurred:");
+            return StatusCode(statusCode, new ApiResponse(statusCode, $"An error has occurred: {ex.Message}"));
+        }
+    }
+
+    /// <summary>
+    ///     Get the robot status
+    /// </summary>
+    /// <returns> the list of RobotStatusModel entities </returns>
+    [HttpGet]
+    [Route("netapp/{id}", Name = "NetAppStatusGetById")]
+    [ProducesResponseType(typeof(NetAppStatusModel), (int)HttpStatusCode.OK)]
+    [ProducesResponseType(typeof(ApiResponse), (int)HttpStatusCode.BadRequest)]
+    [ProducesResponseType(typeof(ApiResponse), (int)HttpStatusCode.NotFound)]
+    [ProducesResponseType(typeof(ApiResponse), (int)HttpStatusCode.InternalServerError)]
+    public async Task<ActionResult<NetAppStatusModel>> GetNetAppStatusByIdAsync(Guid id, bool generateFakeData = false)
     {
         if (id == Guid.Empty)
         {
@@ -113,10 +182,13 @@ public class StatusController : Controller
         try
         {
             //TODO: put behind service
-            var status = await _netAppStatusRepository.GetByIdAsync(id);
+            var status = await _heartbeatService.GetNetAppStatusByIdAsync(id, generateFakeData);
             if (status is null)
+            {
                 return NotFound(new ApiResponse((int)HttpStatusCode.NotFound,
                     "Status for the specified robot was not found."));
+            }
+
             return Ok(status);
         }
         catch (Exception ex)

--- a/src/Orchestrator/Controllers/StatusController.cs
+++ b/src/Orchestrator/Controllers/StatusController.cs
@@ -48,10 +48,10 @@ public class StatusController : Controller
         try
         {
             var status = await _heartbeatService.GetAllRobotStatusesAsync(generateFakeData);
-            if (status is null)
+            if (status is null || !status.Any())
             {
                 return NotFound(new ApiResponse((int)HttpStatusCode.NotFound,
-                    "Status for the specified robot was not found."));
+                    "No robot statuses were found."));
             }
 
             return Ok(status);
@@ -145,10 +145,10 @@ public class StatusController : Controller
         try
         {
             var status = await _heartbeatService.GetAllAppStatusesAsync(generateFakeData);
-            if (status is null)
+            if (status is null || !status.Any())
             {
                 return NotFound(new ApiResponse((int)HttpStatusCode.NotFound,
-                    "Status for the specified robot was not found."));
+                    "No NetApp statuses were found."));
             }
 
             return Ok(status);
@@ -181,12 +181,11 @@ public class StatusController : Controller
 
         try
         {
-            //TODO: put behind service
             var status = await _heartbeatService.GetNetAppStatusByIdAsync(id, generateFakeData);
             if (status is null)
             {
                 return NotFound(new ApiResponse((int)HttpStatusCode.NotFound,
-                    "Status for the specified robot was not found."));
+                    "Status for the specified NetApp was not found."));
             }
 
             return Ok(status);

--- a/src/Orchestrator/ExtensionMethods/ServiceCollectionExtensions.cs
+++ b/src/Orchestrator/ExtensionMethods/ServiceCollectionExtensions.cs
@@ -37,6 +37,8 @@ public static class ServiceCollectionExtensions
                     hostConfig.Password(mqConfig.Pass);
                 });
 
+                #region consumer configuration
+
                 mqBusFactoryConfigurator.ReceiveEndpoint(
                     QueueHelpers.ConstructSwitchoverDeleteActionQueueName(mwConfig.Organization,
                         mwConfig.InstanceName),
@@ -91,8 +93,10 @@ public static class ServiceCollectionExtensions
                         ec.ConfigureConsumer<ConnectRobotToSliceConsumer>(busRegistrationContext);
                     });
 
+                #endregion
 
-                #region consumer configuration
+
+                #region publisher configuration
 
                 mqBusFactoryConfigurator.Send<GatewayAddNetAppEntryMessage>(topologyConfigurator =>
                 {

--- a/src/Orchestrator/Heartbeat/HeartbeatService.cs
+++ b/src/Orchestrator/Heartbeat/HeartbeatService.cs
@@ -1,0 +1,108 @@
+﻿using Middleware.DataAccess.Repositories.Abstract;
+using Middleware.Models.Domain;
+using Middleware.RedisInterface.Sdk;
+
+namespace Middleware.Orchestrator.Heartbeat;
+
+internal class HeartbeatService : IHeartbeatService
+{
+    private readonly ILogger _logger;
+    private readonly INetAppStatusRepository _netAppStatusRepository;
+    private readonly IRedisInterfaceClient _redisInterfaceClient;
+    private readonly IRobotStatusRepository _robotStatusRepository;
+
+    public HeartbeatService(IRobotStatusRepository robotStatusRepository, IRedisInterfaceClient redisInterfaceClient,
+        INetAppStatusRepository netAppStatusRepository, ILogger<HeartbeatService> logger)
+    {
+        _robotStatusRepository = robotStatusRepository;
+        _redisInterfaceClient = redisInterfaceClient;
+        _netAppStatusRepository = netAppStatusRepository;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<NetAppStatusModel> GetNetAppStatusByIdAsync(Guid id, bool generateFakeData = false)
+    {
+        var status = await _netAppStatusRepository.GetByIdAsync(id);
+        if (status is null && generateFakeData)
+        {
+            var robotResp = await _redisInterfaceClient.InstanceGetByIdAsync(id);
+            if (robotResp is null) return null;
+            return CreateNewAppStatus(id, robotResp.Name);
+        }
+
+        return status;
+    }
+
+    /// <inheritdoc />
+    public async Task<RobotStatusModel> GetRobotStatusByIdAsync(Guid id, bool generateFakeData = false)
+    {
+        var status = await _robotStatusRepository.GetByIdAsync(id);
+        if (status is null && generateFakeData)
+        {
+            var robotResp = await _redisInterfaceClient.RobotGetByIdAsync(id);
+            if (robotResp is null) return null;
+            return CreateNewRobotStatus(id, robotResp.Name);
+        }
+
+        return status;
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<NetAppStatusModel>> GetAllAppStatusesAsync(bool generateFakeData)
+    {
+        var statuses = await _netAppStatusRepository.GetAllAsync();
+        if (!statuses.Any() && generateFakeData) return await CreateFakeNetAppStatusList();
+        return statuses;
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<RobotStatusModel>> GetAllRobotStatusesAsync(bool generateFakeData = false)
+    {
+        var statuses = await _robotStatusRepository.GetAllAsync();
+        if (!statuses.Any() && generateFakeData) return await CreateFakeRobotStatusList();
+        return statuses;
+    }
+
+    private async Task<IReadOnlyList<RobotStatusModel>> CreateFakeRobotStatusList()
+    {
+        var robotsResponse = await _redisInterfaceClient.RobotGetAllAsync();
+        if (robotsResponse is null) return null;
+
+        return robotsResponse.Robots.Select(i => CreateNewRobotStatus(i.Id, i.Name)).ToList();
+    }
+
+    private async Task<IReadOnlyList<NetAppStatusModel>> CreateFakeNetAppStatusList()
+    {
+        var instancesResp = await _redisInterfaceClient.InstanceGetAllAsync();
+        if (instancesResp is null) return null;
+
+        return instancesResp.Instances.Select(i => CreateNewAppStatus(i.Id, i.Name)).ToList();
+    }
+
+    private NetAppStatusModel CreateNewAppStatus(Guid id, string name)
+    {
+        return new()
+        {
+            Id = id,
+            Name = name,
+            Timestamp = DateTimeOffset.Now - TimeSpan.FromSeconds(Random.Shared.Next(1, 10)),
+            CurrentRobotsCount = Random.Shared.Next(0, 3),
+            OptimalLimit = Random.Shared.Next(2, 4),
+            HardLimit = Random.Shared.Next(4, 6)
+        };
+    }
+
+    private RobotStatusModel CreateNewRobotStatus(Guid id, string name)
+    {
+        return new()
+        {
+            Id = id,
+            Name = name,
+            Timestamp = DateTimeOffset.Now - TimeSpan.FromSeconds(Random.Shared.Next(1, 10)),
+            ActionSequenceId = Guid.NewGuid(),
+            CurrentlyExecutedActionIndex = Random.Shared.Next(1, 4),
+            BatteryLevel = Random.Shared.Next(1, 100)
+        };
+    }
+}

--- a/src/Orchestrator/Heartbeat/IHeartbeatService.cs
+++ b/src/Orchestrator/Heartbeat/IHeartbeatService.cs
@@ -1,0 +1,11 @@
+﻿using Middleware.Models.Domain;
+
+namespace Middleware.Orchestrator.Heartbeat;
+
+public interface IHeartbeatService
+{
+    Task<NetAppStatusModel> GetNetAppStatusByIdAsync(Guid id, bool generateFakeData = false);
+    Task<RobotStatusModel> GetRobotStatusByIdAsync(Guid id, bool generateFakeData = false);
+    Task<IReadOnlyList<NetAppStatusModel>> GetAllAppStatusesAsync(bool generateFakeData = false);
+    Task<IReadOnlyList<RobotStatusModel>> GetAllRobotStatusesAsync(bool generateFakeData = false);
+}

--- a/src/Orchestrator/Models/Responses/GetNetAppStatusesResponse.cs
+++ b/src/Orchestrator/Models/Responses/GetNetAppStatusesResponse.cs
@@ -1,0 +1,8 @@
+﻿using Middleware.Models.Domain;
+
+namespace Middleware.Orchestrator.Models.Responses;
+
+public class GetNetAppStatusesResponse
+{
+    public IEnumerable<NetAppStatusModel> NetApps { get; set; } = Enumerable.Empty<NetAppStatusModel>();
+}

--- a/src/Orchestrator/Models/Responses/GetRobotStatusesResponse.cs
+++ b/src/Orchestrator/Models/Responses/GetRobotStatusesResponse.cs
@@ -1,0 +1,8 @@
+﻿using Middleware.Models.Domain;
+
+namespace Middleware.Orchestrator.Models.Responses;
+
+public class GetRobotStatusesResponse
+{
+    public IEnumerable<RobotStatusModel> Robots { get; set; } = Enumerable.Empty<RobotStatusModel>();
+}

--- a/src/Orchestrator/Program.cs
+++ b/src/Orchestrator/Program.cs
@@ -12,6 +12,7 @@ using Middleware.DataAccess.Repositories.Redis;
 using Middleware.Orchestrator.Config;
 using Middleware.Orchestrator.Deployment;
 using Middleware.Orchestrator.ExtensionMethods;
+using Middleware.Orchestrator.Heartbeat;
 using Middleware.Orchestrator.Publishers;
 using Middleware.Orchestrator.SliceManager;
 using Middleware.Orchestrator.SliceManager.Contracts;
@@ -66,6 +67,7 @@ builder.Services.AddScoped<IRosConnectionBuilderFactory, RosConnectionBuilderFac
 builder.Services.AddScoped<IPublishingService, PublishingService>();
 builder.Services.AddScoped<IPublisher<GatewayAddNetAppEntryMessage>, GatewayAddNetAppEntryPublisher>();
 builder.Services.AddScoped<IPublisher<GatewayDeleteNetAppEntryMessage>, GatewayDeleteNetAppEntryPublisher>();
+builder.Services.AddScoped<IHeartbeatService, HeartbeatService>();
 builder.Services.AddRedisInterfaceClient();
 
 builder.Services.AddHttpClient("healthCheckClient");

--- a/src/RedisInterface.Contracts/Responses/LocationResponse.cs
+++ b/src/RedisInterface.Contracts/Responses/LocationResponse.cs
@@ -1,0 +1,12 @@
+﻿namespace Middleware.RedisInterface.Contracts.Responses;
+
+public class LocationResponse
+{
+    public Guid Id { get; init; }
+    public string Name { get; init; } = default!;
+    public string Type { get; init; } = default!;
+    public bool IsOnline { get; init; } = true;
+
+    public Uri IpAddress { get; init; }
+    public IEnumerable<SliceResponse> Slices { get; init; } = Enumerable.Empty<SliceResponse>();
+}

--- a/src/RedisInterface.Contracts/Responses/OrgStructureResponse.cs
+++ b/src/RedisInterface.Contracts/Responses/OrgStructureResponse.cs
@@ -1,0 +1,6 @@
+﻿namespace Middleware.RedisInterface.Contracts.Responses;
+
+public class OrgStructureResponse
+{
+    public IEnumerable<LocationResponse> Locations { get; init; } = Enumerable.Empty<LocationResponse>();
+}

--- a/src/RedisInterface.Sdk/Client/IRedisInterface.cs
+++ b/src/RedisInterface.Sdk/Client/IRedisInterface.cs
@@ -95,4 +95,10 @@ public interface IRedisInterface
 
     [Post("/api/v1/slice/embb")] //doesn't matter if we add it to embb or urllc
     Task<ApiResponse<SliceResponse?>> SliceAddAsync(SliceRequest slice);
+
+    [Get("/api/v1/instance")]
+    Task<ApiResponse<GetInstancesResponse?>> InstanceGetAll();
+
+    [Get("/api/v1/robot")]
+    Task<ApiResponse<GetRobotsResponse?>> RobotGetAll();
 }

--- a/src/RedisInterface.Sdk/IRedisInterfaceClient.cs
+++ b/src/RedisInterface.Sdk/IRedisInterfaceClient.cs
@@ -1,5 +1,4 @@
 using Middleware.Models.Domain;
-using Middleware.Models.Domain.Slice;
 using Middleware.RedisInterface.Contracts.Requests;
 using Middleware.RedisInterface.Contracts.Responses;
 
@@ -110,6 +109,12 @@ public interface IRedisInterfaceClient
     Task<InstanceResponse?> InstanceGetByIdAsync(Guid id);
 
     /// <summary>
+    ///     Get all instance data
+    /// </summary>
+    /// <returns></returns>
+    Task<GetInstancesResponse?> InstanceGetAllAsync();
+
+    /// <summary>
     ///     Retrieves the Container Images associated with the specified Instance
     /// </summary>
     /// <param name="id"></param>
@@ -199,5 +204,6 @@ public interface IRedisInterfaceClient
 
     Task<SliceResponse?> GetBySliceIdAsync(string id);
 
-    Task<bool> SliceAddAsync(SliceRequest slice); 
+    Task<bool> SliceAddAsync(SliceRequest slice);
+    Task<GetRobotsResponse?> RobotGetAllAsync();
 }

--- a/src/RedisInterface.Sdk/RedisInterfaceClient.cs
+++ b/src/RedisInterface.Sdk/RedisInterfaceClient.cs
@@ -112,6 +112,17 @@ public class RedisInterfaceClient : IRedisInterfaceClient
         return await InstanceGetByIdAsync(id, CancellationToken.None);
     }
 
+    /// <inheritdoc />
+    public async Task<GetInstancesResponse?> InstanceGetAllAsync()
+    {
+        var result = await _api.InstanceGetAll();
+
+        if (!result.IsSuccessStatusCode)
+            _logger.LogError(result.Error, "{} - unsuccessful API call", nameof(InstanceGetAllAsync));
+
+        return result.IsSuccessStatusCode ? result.Content : null;
+    }
+
     public async Task<GetContainersResponse?> ContainerImageGetForInstanceAsync(Guid id)
     {
         return await ContainerImageGetForInstanceAsync(id, CancellationToken.None);
@@ -312,6 +323,17 @@ public class RedisInterfaceClient : IRedisInterfaceClient
             _logger.LogError(result.Error, "{} - unsuccessful API call", nameof(ActionPlanAddAsync));
 
         return result.IsSuccessStatusCode;
+    }
+
+    /// <inheritdoc />
+    public async Task<GetRobotsResponse?> RobotGetAllAsync()
+    {
+        var result = await _api.RobotGetAll();
+
+        if (!result.IsSuccessStatusCode)
+            _logger.LogError(result.Error, "{} - unsuccessful API call", nameof(RobotGetAllAsync));
+
+        return result.IsSuccessStatusCode ? result.Content : null;
     }
 
     private RelationModel CreateRelation<TSource, TDirection>(TSource source, TDirection direction, string name)

--- a/src/RedisInterface/Controllers/DashboardController.cs
+++ b/src/RedisInterface/Controllers/DashboardController.cs
@@ -6,192 +6,224 @@ using Middleware.Common.Responses;
 using Middleware.RedisInterface.Contracts.Responses;
 using Middleware.RedisInterface.Services;
 
-namespace Middleware.RedisInterface.Controllers
+namespace Middleware.RedisInterface.Controllers;
+
+[Route("api/v1/[controller]")]
+[ApiController]
+public class DashboardController : ControllerBase
 {
-    [Route("api/v1/[controller]")]
-    [ApiController]
-    public class DashboardController : ControllerBase
+    private readonly IDashboardService _dashboardService;
+    private readonly ILogger<DashboardController> _logger;
+    private readonly IUriService _uriService;
+
+    public DashboardController(IDashboardService dashboardService, ILogger<DashboardController> logger,
+        IUriService uriService)
     {
-        private readonly IDashboardService _dashboardService;
-        private readonly ILogger<DashboardController> _logger;
-        private readonly IUriService _uriService;
-        public DashboardController(IDashboardService dashboardService, ILogger<DashboardController> logger, IUriService uriService)
+        _uriService = uriService;
+        _logger = logger;
+        _dashboardService = dashboardService;
+    }
+
+    /// <summary>
+    ///     Basic control grid for robot-tasks
+    /// </summary>
+    /// <param name="filter"></param>
+    /// <returns></returns>
+    [HttpGet("tasks")]
+    [ProducesResponseType(typeof(PagedResponse<List<TaskRobotResponse>>), (int)HttpStatusCode.OK)]
+    [ProducesResponseType(typeof(ApiResponse), (int)HttpStatusCode.InternalServerError)]
+    public async Task<IActionResult> GetTaskRobotResponseAsync([FromQuery] PaginationFilter filter)
+    {
+        try
         {
-            _uriService = uriService;
-            _logger = logger;
-            _dashboardService = dashboardService;
+            var route = Request.Path.Value;
+            var (data, count) = await _dashboardService.GetRobotStatusListAsync(filter);
+
+            var pagedResponse = data.ToPagedResponse(filter, count, _uriService, route);
+            return Ok(pagedResponse);
         }
-
-        /// <summary>
-        /// Basic control grid for robot-tasks
-        /// </summary>
-        /// <param name="filter"></param>
-        /// <returns></returns>
-        [HttpGet("tasks")]
-        [ProducesResponseType(typeof(PagedResponse<List<TaskRobotResponse>>), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(ApiResponse), (int)HttpStatusCode.InternalServerError)]
-        public async Task<IActionResult> GetTaskRobotResponseAsync([FromQuery] PaginationFilter filter)
+        catch (Exception ex)
         {
-            try
-            {
-                var route = Request.Path.Value;
-                (var data, int count) = await _dashboardService.GetRobotStatusListAsync(filter);
-
-                var pagedResponse = data.ToPagedResponse(filter, count, _uriService, route);
-                return Ok(pagedResponse);
-            }
-            catch (Exception ex)
-            {
-                int statusCode = (int)HttpStatusCode.InternalServerError;
-                _logger.LogError(ex, "An error occurred:");
-                return StatusCode(statusCode, new ApiResponse(statusCode, $"An error has occurred: {ex.Message}"));
-            }
-
+            var statusCode = (int)HttpStatusCode.InternalServerError;
+            _logger.LogError(ex, "An error occurred:");
+            return StatusCode(statusCode, new ApiResponse(statusCode, $"An error has occurred: {ex.Message}"));
         }
+    }
 
-        /// <summary>
-        /// Basic control grid for edge and cloud
-        /// </summary>
-        /// <param name="filter"></param>
-        /// <returns></returns>
-        [HttpGet("locations")]
-        [ProducesResponseType(typeof(PagedResponse<List<LocationStatusResponse>>), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(ApiResponse), (int)HttpStatusCode.InternalServerError)]
-        public async Task<IActionResult> GetLocationStatusesAsync([FromQuery] PaginationFilter filter)
+    /// <summary>
+    ///     Basic control grid for edge and cloud
+    /// </summary>
+    /// <param name="filter"></param>
+    /// <returns></returns>
+    [HttpGet("locations")]
+    [ProducesResponseType(typeof(PagedResponse<List<LocationStatusResponse>>), (int)HttpStatusCode.OK)]
+    [ProducesResponseType(typeof(ApiResponse), (int)HttpStatusCode.InternalServerError)]
+    public async Task<IActionResult> GetLocationStatusesAsync([FromQuery] PaginationFilter filter)
+    {
+        try
         {
-            try
-            {
-                var route = Request.Path.Value;
-                (var data, int count) = await _dashboardService.GetLocationsStatusListAsync(filter);
+            var route = Request.Path.Value;
+            var (data, count) = await _dashboardService.GetLocationsStatusListAsync(filter);
 
-                var pagedResponse = data.ToPagedResponse(filter, count, _uriService, route);
-                return Ok(pagedResponse);
-            }
-            catch (Exception ex)
-            {
-                int statusCode = (int)HttpStatusCode.InternalServerError;
-                _logger.LogError(ex, "An error occurred:");
-                return StatusCode(statusCode, new ApiResponse(statusCode, $"An error has occurred: {ex.Message}"));
-            }
+            var pagedResponse = data.ToPagedResponse(filter, count, _uriService, route);
+            return Ok(pagedResponse);
         }
-
-        /// <summary>
-        /// Return to the cascading grid the action sequence names for all tasks
-        /// </summary>
-        /// <returns></returns>
-        [HttpGet("tasks/actions")]
-        [ProducesResponseType(typeof(ActionSequenceResponse), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(ApiResponse), (int)HttpStatusCode.InternalServerError)]
-        public async Task<IActionResult> GetActionSequenceAsync()
+        catch (Exception ex)
         {
-            try
-            {
-                List<ActionSequenceResponse> actionsAndTask = await _dashboardService.GetActionSequenceAsync();
-                return Ok(actionsAndTask);
-            }
-            catch (Exception ex)
-            {
-                int statusCode = (int)HttpStatusCode.InternalServerError;
-                _logger.LogError(ex, "An error occurred:");
-                return StatusCode(statusCode, new ApiResponse(statusCode, $"An error has occurred: {ex.Message}"));
-            }
+            var statusCode = (int)HttpStatusCode.InternalServerError;
+            _logger.LogError(ex, "An error occurred:");
+            return StatusCode(statusCode, new ApiResponse(statusCode, $"An error has occurred: {ex.Message}"));
         }
+    }
 
-        /// <summary>
-        /// Return the onboarding types names => Drop down menu.
-        /// </summary>
-        /// <returns></returns>
-        [HttpGet("types")]
-        [ProducesResponseType(typeof(ActionSequenceResponse), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(ApiResponse), (int)HttpStatusCode.InternalServerError)]
-        public async Task<IActionResult> GetOnboardingItemTypesAsync()
+    /// <summary>
+    ///     Return to the cascading grid the action sequence names for all tasks
+    /// </summary>
+    /// <returns></returns>
+    [HttpGet("tasks/actions")]
+    [ProducesResponseType(typeof(ActionSequenceResponse), (int)HttpStatusCode.OK)]
+    [ProducesResponseType(typeof(ApiResponse), (int)HttpStatusCode.InternalServerError)]
+    public async Task<IActionResult> GetActionSequenceAsync()
+    {
+        try
         {
-            try
-            {
-                List<string> onboardingTypes = _dashboardService.GetOnboardingItemNames();
-                return Ok(onboardingTypes);
-            }
-            catch (Exception ex)
-            {
-                int statusCode = (int)HttpStatusCode.InternalServerError;
-                _logger.LogError(ex, "An error occurred:");
-                return StatusCode(statusCode, new ApiResponse(statusCode, $"An error has occurred: {ex.Message}"));
-            }
+            var actionsAndTask = await _dashboardService.GetActionSequenceAsync();
+            return Ok(actionsAndTask);
         }
-
-        /// <summary>
-        /// Basic control grid for netApps
-        /// </summary>
-        /// <param name="filter"></param>
-        /// <returns></returns>
-        [HttpGet("netApps")]
-        [ProducesResponseType(typeof(PagedResponse<List<NetAppsDetailsResponse>>), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(ApiResponse), (int)HttpStatusCode.InternalServerError)]
-        public async Task<IActionResult> GetNetAppsDataAsync([FromQuery] PaginationFilter filter)
+        catch (Exception ex)
         {
-            try
-            {
-                var route = Request.Path.Value;
-                (var data, int count) = await _dashboardService.GetNetAppsDataListAsync(filter);
-
-                var pagedResponse = data.ToPagedResponse(filter, count, _uriService, route);
-                return Ok(pagedResponse);
-            }
-            catch (Exception ex)
-            {
-                int statusCode = (int)HttpStatusCode.InternalServerError;
-                _logger.LogError(ex, "An error occurred:");
-                return StatusCode(statusCode, new ApiResponse(statusCode, $"An error has occurred: {ex.Message}"));
-            }
+            var statusCode = (int)HttpStatusCode.InternalServerError;
+            _logger.LogError(ex, "An error occurred:");
+            return StatusCode(statusCode, new ApiResponse(statusCode, $"An error has occurred: {ex.Message}"));
         }
+    }
 
-        /// <summary>
-        /// Basic control grid for robots along
-        /// </summary>
-        /// <param name="filter"></param>
-        /// <returns></returns>
-        [HttpGet("robots")]
-        [ProducesResponseType(typeof(PagedResponse<List<DashboardRobotResponse>>), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(ApiResponse), (int)HttpStatusCode.InternalServerError)]
-        public async Task<IActionResult> GetRobotsAsync([FromQuery] PaginationFilter filter)
+    /// <summary>
+    ///     Return the onboarding types names => Drop down menu.
+    /// </summary>
+    /// <returns></returns>
+    [HttpGet("types")]
+    [ProducesResponseType(typeof(ActionSequenceResponse), (int)HttpStatusCode.OK)]
+    [ProducesResponseType(typeof(ApiResponse), (int)HttpStatusCode.InternalServerError)]
+    public async Task<IActionResult> GetOnboardingItemTypesAsync()
+    {
+        try
         {
-            try
-            {
-                var route = Request.Path.Value;
-                (var data, int count) = await _dashboardService.GetRobotsDataAsync(filter);
-
-                var pagedResponse = data.ToPagedResponse(filter, count, _uriService, route);
-                return Ok(pagedResponse);
-            }
-            catch (Exception ex)
-            {
-                int statusCode = (int)HttpStatusCode.InternalServerError;
-                _logger.LogError(ex, "An error occurred:");
-                return StatusCode(statusCode, new ApiResponse(statusCode, $"An error has occurred: {ex.Message}"));
-            }
+            var onboardingTypes = _dashboardService.GetOnboardingItemNames();
+            return Ok(onboardingTypes);
         }
-
-        /// <summary>
-        /// Return the Graph
-        /// </summary>
-        /// <returns></returns>
-        [HttpGet("graph")]
-        [ProducesResponseType(typeof(GraphResponse), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(ApiResponse), (int)HttpStatusCode.InternalServerError)]
-        public async Task<IActionResult> GetGraphAsync()
+        catch (Exception ex)
         {
-            try
-            {
-                var relations = await _dashboardService.GetAllRelationModelsAsync();
+            var statusCode = (int)HttpStatusCode.InternalServerError;
+            _logger.LogError(ex, "An error occurred:");
+            return StatusCode(statusCode, new ApiResponse(statusCode, $"An error has occurred: {ex.Message}"));
+        }
+    }
 
-                return Ok(relations);
-            }
-            catch (Exception ex)
+    /// <summary>
+    ///     Basic control grid for netApps
+    /// </summary>
+    /// <param name="filter"></param>
+    /// <returns></returns>
+    [HttpGet("netApps")]
+    [ProducesResponseType(typeof(PagedResponse<List<NetAppsDetailsResponse>>), (int)HttpStatusCode.OK)]
+    [ProducesResponseType(typeof(ApiResponse), (int)HttpStatusCode.InternalServerError)]
+    public async Task<IActionResult> GetNetAppsDataAsync([FromQuery] PaginationFilter filter)
+    {
+        try
+        {
+            var route = Request.Path.Value;
+            var (data, count) = await _dashboardService.GetNetAppsDataListAsync(filter);
+
+            var pagedResponse = data.ToPagedResponse(filter, count, _uriService, route);
+            return Ok(pagedResponse);
+        }
+        catch (Exception ex)
+        {
+            var statusCode = (int)HttpStatusCode.InternalServerError;
+            _logger.LogError(ex, "An error occurred:");
+            return StatusCode(statusCode, new ApiResponse(statusCode, $"An error has occurred: {ex.Message}"));
+        }
+    }
+
+    /// <summary>
+    ///     Basic control grid for robots along
+    /// </summary>
+    /// <param name="filter"></param>
+    /// <returns></returns>
+    [HttpGet("robots")]
+    [ProducesResponseType(typeof(PagedResponse<List<DashboardRobotResponse>>), (int)HttpStatusCode.OK)]
+    [ProducesResponseType(typeof(ApiResponse), (int)HttpStatusCode.InternalServerError)]
+    public async Task<IActionResult> GetRobotsAsync([FromQuery] PaginationFilter filter)
+    {
+        try
+        {
+            var route = Request.Path.Value;
+            var (data, count) = await _dashboardService.GetRobotsDataAsync(filter);
+
+            var pagedResponse = data.ToPagedResponse(filter, count, _uriService, route);
+            return Ok(pagedResponse);
+        }
+        catch (Exception ex)
+        {
+            var statusCode = (int)HttpStatusCode.InternalServerError;
+            _logger.LogError(ex, "An error occurred:");
+            return StatusCode(statusCode, new ApiResponse(statusCode, $"An error has occurred: {ex.Message}"));
+        }
+    }
+
+    /// <summary>
+    ///     Return the Graph
+    /// </summary>
+    /// <returns></returns>
+    [HttpGet("graph")]
+    [ProducesResponseType(typeof(GraphResponse), (int)HttpStatusCode.OK)]
+    [ProducesResponseType(typeof(ApiResponse), (int)HttpStatusCode.InternalServerError)]
+    public async Task<IActionResult> GetGraphAsync()
+    {
+        try
+        {
+            var relations = await _dashboardService.GetAllRelationModelsAsync();
+
+            return Ok(relations);
+        }
+        catch (Exception ex)
+        {
+            var statusCode = (int)HttpStatusCode.InternalServerError;
+            _logger.LogError(ex, "An error occurred:");
+            return StatusCode(statusCode, new ApiResponse(statusCode, $"An error has occurred: {ex.Message}"));
+        }
+    }
+
+    /// <summary>
+    ///     Return the organization structure
+    /// </summary>
+    /// <returns></returns>
+    [HttpGet("org/{orgName}")]
+    [ProducesResponseType(typeof(OrgStructureResponse), (int)HttpStatusCode.OK)]
+    [ProducesResponseType(typeof(ApiResponse), (int)HttpStatusCode.InternalServerError)]
+    public async Task<IActionResult> GetOrganizationStructureAsync(string orgName = "5G-ERA")
+    {
+        try
+        {
+            var structure = await _dashboardService.GetOrganizationStructureAsync(orgName);
+            if (structure is null || !structure.Any())
             {
-                int statusCode = (int)HttpStatusCode.InternalServerError;
-                _logger.LogError(ex, "An error occurred:");
-                return StatusCode(statusCode, new ApiResponse(statusCode, $"An error has occurred: {ex.Message}"));
+                return NotFound(new ApiResponse((int)HttpStatusCode.NotFound,
+                    "The structure for the following organization was not found."));
             }
+
+            var resp = new OrgStructureResponse
+            {
+                Locations = structure
+            };
+            return Ok(resp);
+        }
+        catch (Exception ex)
+        {
+            var statusCode = (int)HttpStatusCode.InternalServerError;
+            _logger.LogError(ex, "An error occurred:");
+            return StatusCode(statusCode, new ApiResponse(statusCode, $"An error has occurred: {ex.Message}"));
         }
     }
 }

--- a/src/RedisInterface/Program.cs
+++ b/src/RedisInterface/Program.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using Middleware.CentralApi.Sdk;
 using Middleware.Common.Config;
 using Middleware.Common.ExtensionMethods;
 using Middleware.DataAccess.ExtensionMethods;
@@ -20,6 +21,11 @@ builder.RegisterSecretsManager();
 
 builder.ConfigureLogger();
 
+var mwConfig = builder.Configuration.GetSection(MiddlewareConfig.ConfigName).Get<MiddlewareConfig>();
+var centralApiHostname = Environment.GetEnvironmentVariable("CENTRAL_API_HOSTNAME");
+if (centralApiHostname is null)
+    throw new ArgumentException("Environment variable not defined: CENTRAL_API_HOSTNAME", "CENTRAL_API_HOSTNAME");
+
 builder.Services.Configure<MiddlewareConfig>(builder.Configuration.GetSection(MiddlewareConfig.ConfigName));
 
 // Add services to the container.
@@ -30,8 +36,6 @@ builder.Services.AddControllers(options =>
     .AddNewtonsoftJson(x => { x.SerializerSettings.ReferenceLoopHandling = ReferenceLoopHandling.Ignore; });
 builder.Services.AddFluentValidation(typeof(Program));
 
-// Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
-
 builder.Services.AddSwaggerGen();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddHttpClient("healthCheckClient");
@@ -40,10 +44,12 @@ builder.RegisterRedis();
 builder.Services.AddUriHelper();
 builder.Services.AddHostedService<IndexCreationService>();
 builder.Services.RegisterRepositories();
+builder.Services.AddCentralApiClient(centralApiHostname, mwConfig.Organization);
 builder.Services.AddScoped<IDashboardService, DashboardService>();
 builder.Services.AddScoped<IActionService, ActionService>();
 builder.Services.AddScoped<ISliceService, SliceService>();
 builder.Services.AddScoped<ITaskService, TaskService>();
+
 var app = builder.Build();
 
 // Configure the HTTP request pipeline.

--- a/src/RedisInterface/RedisInterface.csproj
+++ b/src/RedisInterface/RedisInterface.csproj
@@ -32,6 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\CentralApi.Sdk\CentralApi.Sdk.csproj" />
     <ProjectReference Include="..\Common\Common.csproj" />
     <ProjectReference Include="..\DataAccess\DataAccess.csproj" />
     <ProjectReference Include="..\RedisInterface.Contracts\RedisInterface.Contracts.csproj" />

--- a/src/RedisInterface/Services/Abstract/IDashboardService.cs
+++ b/src/RedisInterface/Services/Abstract/IDashboardService.cs
@@ -1,36 +1,40 @@
 ﻿using Middleware.Common;
 using Middleware.RedisInterface.Contracts.Responses;
 
-namespace Middleware.RedisInterface.Services
+namespace Middleware.RedisInterface.Services;
+
+public interface IDashboardService
 {
-    public interface IDashboardService
-    {
-        /// <summary>
-        /// Gets the list of tasks that were executed by the robots
-        /// </summary>
-        /// <param name="filter"></param>
-        /// <returns>A tuple of values: <br/>
-        ///     First: A list of <seealso cref="TaskRobotResponse"/> <br/>
-        ///     Second: Total number of records</returns>
-        Task<Tuple<List<TaskRobotResponse>, int>> GetRobotStatusListAsync(PaginationFilter filter);
+    /// <summary>
+    ///     Gets the list of tasks that were executed by the robots
+    /// </summary>
+    /// <param name="filter"></param>
+    /// <returns>
+    ///     A tuple of values: <br />
+    ///     First: A list of <seealso cref="TaskRobotResponse" /> <br />
+    ///     Second: Total number of records
+    /// </returns>
+    Task<Tuple<List<TaskRobotResponse>, int>> GetRobotStatusListAsync(PaginationFilter filter);
 
-        /// <summary>
-        /// Gets the list the locations registered with the Middleware (Clouds and Edges)
-        /// </summary>
-        /// <param name="filter"></param>
-        /// <returns>A tuple of values: <br/>
-        ///     First: A list of <seealso cref="LocationStatusResponse"/> <br/>
-        ///     Second: Total number of records</returns>
-        Task<Tuple<List<LocationStatusResponse>, int>> GetLocationsStatusListAsync(PaginationFilter filter);
+    /// <summary>
+    ///     Gets the list the locations registered with the Middleware (Clouds and Edges)
+    /// </summary>
+    /// <param name="filter"></param>
+    /// <returns>
+    ///     A tuple of values: <br />
+    ///     First: A list of <seealso cref="LocationStatusResponse" /> <br />
+    ///     Second: Total number of records
+    /// </returns>
+    Task<Tuple<List<LocationStatusResponse>, int>> GetLocationsStatusListAsync(PaginationFilter filter);
 
-        Task<List<ActionSequenceResponse>> GetActionSequenceAsync();
+    Task<List<ActionSequenceResponse>> GetActionSequenceAsync();
 
-        List<string> GetOnboardingItemNames();
+    List<string> GetOnboardingItemNames();
 
-        Task<Tuple<List<NetAppsDetailsResponse>, int>> GetNetAppsDataListAsync(PaginationFilter filter);
+    Task<Tuple<List<NetAppsDetailsResponse>, int>> GetNetAppsDataListAsync(PaginationFilter filter);
 
-        Task<Tuple<List<DashboardRobotResponse>, int>> GetRobotsDataAsync(PaginationFilter filter);
+    Task<Tuple<List<DashboardRobotResponse>, int>> GetRobotsDataAsync(PaginationFilter filter);
 
-        Task<GraphResponse> GetAllRelationModelsAsync();
-    }
+    Task<GraphResponse> GetAllRelationModelsAsync();
+    Task<IReadOnlyList<LocationResponse>> GetOrganizationStructureAsync(string orgName);
 }


### PR DESCRIPTION
# Description

This feature requests adding new endpoints to the Middleware API to provide a dashboard with the operational data from the Middleware.

The endpoints should provide:

* Heartbeat information from all the NetApps (filled with dummy data if no data is found)
* Heartbeat information from all the Robots (filled with dummy data if no data is found)
* Information about the Organization structure containing onboarded locations (Edges and Clouds) and Slicing capabilities.

Fixes #204 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## What has been changed?

1. Feature: new endpoints containing operational data for the dashboard were added

# How Has This Been Tested?

- [x] Test A: manual tests of the outputs from the endpoints
- [x] Test B: data compared with the

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes