### PR TITLE
fix: add missing ROS2 support for the Relay NetApp

### DIFF
--- a/src/Orchestrator/Deployment/Abstract/IRosConnectionBuilder.cs
+++ b/src/Orchestrator/Deployment/Abstract/IRosConnectionBuilder.cs
@@ -1,7 +1,6 @@
 using k8s.Models;
 using Middleware.Models.Domain;
 
-
 namespace Middleware.Orchestrator.Deployment;
 
 internal interface IRosConnectionBuilder
@@ -20,9 +19,11 @@ internal interface IRosConnectionBuilder
     ///     Enables the communication using ROS between the services within deployment
     /// </summary>
     /// <param name="dpl"></param>
-    /// <param name="rosTopics"></param>
+    /// <param name="topicSubscribers"></param>
+    /// <param name="topicPublishers"></param>
     /// <returns></returns>
-    V1Deployment EnableRosCommunication(V1Deployment dpl, IReadOnlyList<RosTopicModel> rosTopics);
+    V1Deployment EnableRosCommunication(V1Deployment dpl, IReadOnlyList<RosTopicModel> topicSubscribers,
+        IReadOnlyList<RosTopicModel> topicPublishers);
 
     /// <summary>
     ///     Enables the communication with the service to the Relay NetApp

--- a/src/Orchestrator/Deployment/DeploymentService.cs
+++ b/src/Orchestrator/Deployment/DeploymentService.cs
@@ -469,8 +469,9 @@ internal class DeploymentService : IDeploymentService
 
         if (builder is not null)
         {
-            var topics = instance.RosTopicsPub.CreateCopy();
-            deployment = builder.EnableRosCommunication(deployment, topics);
+            var topicPub = instance.RosTopicsPub.CreateCopy();
+            var topicSub = instance.RosTopicsSub.CreateCopy();
+            deployment = builder.EnableRosCommunication(deployment, topicSub, topicPub);
         }
 
         var service = string.IsNullOrWhiteSpace(cim.K8SService)

--- a/src/Orchestrator/Deployment/RosCommunication/Ros1ConnectionBuilder.cs
+++ b/src/Orchestrator/Deployment/RosCommunication/Ros1ConnectionBuilder.cs
@@ -1,6 +1,4 @@
 using System.Text.Json;
-using System.Text.Json.Serialization;
-using JetBrains.Annotations;
 using k8s.Models;
 using Middleware.Common.ExtensionMethods;
 using Middleware.Models.Domain;
@@ -42,9 +40,10 @@ internal class Ros1ConnectionBuilder : IRosConnectionBuilder
     }
 
     /// <inheritdoc />
-    public V1Deployment EnableRosCommunication(V1Deployment dpl, IReadOnlyList<RosTopicModel> rosTopics)
+    public V1Deployment EnableRosCommunication(V1Deployment dpl, IReadOnlyList<RosTopicModel> topicSubscribers,
+        IReadOnlyList<RosTopicModel> topicPublishers)
     {
-        if (rosTopics is null) throw new ArgumentNullException(nameof(rosTopics));
+        if (topicSubscribers is null) throw new ArgumentNullException(nameof(topicSubscribers));
         if (dpl.Spec?.Template?.Spec?.Containers is null || dpl.Spec.Template.Spec.Containers.Any() == false)
             throw new ArgumentException("Missing Deployment container configuration.", nameof(dpl));
 
@@ -59,7 +58,8 @@ internal class Ros1ConnectionBuilder : IRosConnectionBuilder
         }
 
         dpl.Spec.Template.Spec.Containers.Add(GetRosContainer());
-        dpl.Spec.Template.Spec.Containers.Add(GetRelayNetAppContainer(rosTopics));
+        //MK 2023.10.20: ROS1 version of Relay only needs to know the topics FROM cloud TO robot
+        dpl.Spec.Template.Spec.Containers.Add(GetRelayNetAppContainer(topicPublishers));
 
         return dpl;
     }
@@ -100,26 +100,5 @@ internal class Ros1ConnectionBuilder : IRosConnectionBuilder
         };
 
         return container;
-    }
-
-    /// <summary>
-    ///     Temporary class to parse the RosTopicModel into the correct format
-    /// </summary>
-    private class RosTopicContainer
-    {
-        [JsonPropertyName("topic_name")]
-        public string Name { [UsedImplicitly] get; init; }
-
-        [JsonPropertyName("topic_type")]
-        public string Type { [UsedImplicitly] get; init; }
-
-        public static RosTopicContainer FromRosTopicModel(RosTopicModel topic)
-        {
-            return new()
-            {
-                Name = topic.Name,
-                Type = topic.Type
-            };
-        }
     }
 }

--- a/src/Orchestrator/Deployment/RosCommunication/Ros2ConnectionBuilder.cs
+++ b/src/Orchestrator/Deployment/RosCommunication/Ros2ConnectionBuilder.cs
@@ -1,4 +1,6 @@
-﻿using k8s.Models;
+﻿using System.Text.Json;
+using k8s.Models;
+using Middleware.Common.ExtensionMethods;
 using Middleware.Models.Domain;
 
 namespace Middleware.Orchestrator.Deployment.RosCommunication;
@@ -28,15 +30,55 @@ internal class Ros2ConnectionBuilder : IRosConnectionBuilder
     public string RosDistro { get; }
 
     /// <inheritdoc />
-    public V1Deployment EnableRosCommunication(V1Deployment dpl, IReadOnlyList<RosTopicModel> topicSubscribers)
+    public V1Deployment EnableRosCommunication(V1Deployment dpl, IReadOnlyList<RosTopicModel> topicSubscribers,
+        IReadOnlyList<RosTopicModel> topicPublishers)
     {
-        //TODO: we have to figure out how to enable ros2. It is possible that it will be same as ros1, but we will see :)
+        if (topicSubscribers is null) throw new ArgumentNullException(nameof(topicSubscribers));
+        if (dpl.Spec?.Template?.Spec?.Containers is null || dpl.Spec.Template.Spec.Containers.Any() == false)
+            throw new ArgumentException("Missing Deployment container configuration.", nameof(dpl));
+
+        dpl.Spec.Template.Spec.Containers.Add(GetRelayNetAppContainer(topicSubscribers, topicPublishers));
+
         return dpl;
     }
 
     /// <inheritdoc />
     public V1Service EnableRelayNetAppCommunication(V1Service service)
     {
-        throw new NotImplementedException();
+        if (service is null) throw new ArgumentNullException(nameof(service));
+        if (service.Spec?.Ports is null) throw new ArgumentNullException(nameof(service), "Ports list cannot be null");
+
+        if (service.ContainsWebsocketCompatiblePort() == false)
+            service.AddWebsocketCompatiblePort();
+
+        return service;
+    }
+
+    private V1Container GetRelayNetAppContainer(IReadOnlyList<RosTopicModel> topicSubscribers,
+        IReadOnlyList<RosTopicModel> topicPublishers)
+    {
+        var subscribersContainers = topicSubscribers.Select(RosTopicContainer.FromRosTopicModel).ToList();
+        var publishersContainers = topicPublishers.Select(RosTopicContainer.FromRosTopicModel).ToList();
+        var subscribersString = JsonSerializer.Serialize(subscribersContainers);
+        var publishersString = JsonSerializer.Serialize(publishersContainers);
+        var container = new V1Container
+        {
+            Name = "relay-net-app",
+            Ports = new List<V1ContainerPort>
+            {
+                new(80, name: "websocket")
+            },
+            Env = new List<V1EnvVar>
+            {
+                new("TOPIC_LIST",
+                    publishersString), // MK 2023.10.20: TOPIC_LIST - list of topics to be sent FROM cloud TO robot
+                new("TOPIC_TO_PUB_LIST",
+                    subscribersString), // MK 2023.10.20: TOPIC_TO_PUB_LIST - list of topics to be sent FROM robot TO cloud
+                new("NETAPP_PORT", "80")
+            },
+            Image = "but5gera/ros2_relay_server:0.1.0"
+        };
+
+        return container;
     }
 }

--- a/src/Orchestrator/Deployment/RosCommunication/RosTopicContainer.cs
+++ b/src/Orchestrator/Deployment/RosCommunication/RosTopicContainer.cs
@@ -1,0 +1,26 @@
+﻿using System.Text.Json.Serialization;
+using JetBrains.Annotations;
+using Middleware.Models.Domain;
+
+namespace Middleware.Orchestrator.Deployment.RosCommunication;
+
+/// <summary>
+///     Temporary class to parse the RosTopicModel into the correct format
+/// </summary>
+internal class RosTopicContainer
+{
+    [JsonPropertyName("topic_name")]
+    public string Name { [UsedImplicitly] get; init; }
+
+    [JsonPropertyName("topic_type")]
+    public string Type { [UsedImplicitly] get; init; }
+
+    public static RosTopicContainer FromRosTopicModel(RosTopicModel topic)
+    {
+        return new()
+        {
+            Name = topic.Name,
+            Type = topic.Type
+        };
+    }
+}

--- a/test/Orchestrator.Tests.Unit/Deployment/Ros1ConnectionBuilderTests.cs
+++ b/test/Orchestrator.Tests.Unit/Deployment/Ros1ConnectionBuilderTests.cs
@@ -33,7 +33,7 @@ public class Ros1ConnectionBuilderTests
         var sut = new Ros1ConnectionBuilder(distro);
         var topics = new List<RosTopicModel>();
         //act
-        var result = sut.EnableRosCommunication(depl, topics);
+        var result = sut.EnableRosCommunication(depl, topics, topics);
         //assert
         result.Spec.Template.Spec.Containers.Should()
             .HaveCount(3, "We need three containers, one RelayNetApp, one ROS core and NetApp itself");
@@ -72,7 +72,7 @@ public class Ros1ConnectionBuilderTests
             }
         };
         //act
-        var result = sut.EnableRosCommunication(depl, topics);
+        var result = sut.EnableRosCommunication(depl, topics, topics);
 
         //assert
         var relayNetAppContainer = result.Spec.Template.Spec.Containers.FirstOrDefault(c => c.Name == "relay-net-app");


### PR DESCRIPTION
# Description
Added missing support for ROS2 Relay NetApp. Now Middleware can enable communication for ROS2 applications.

Fixes #213 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## What has been changed?

1. Fix: Added missing support for the ROS2 Relay NetApp

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes