### PR TITLE
feat: relations can be retrieved by their relation direction, either …

### DIFF
--- a/src/RedisInterface/Controllers/ActionController.cs
+++ b/src/RedisInterface/Controllers/ActionController.cs
@@ -1,6 +1,8 @@
-﻿using System.Net;
+﻿using System.Linq.Expressions;
+using System.Net;
 using Microsoft.AspNetCore.Mvc;
 using Middleware.Common.Attributes;
+using Middleware.Common.Enums;
 using Middleware.Common.Responses;
 using Middleware.DataAccess.Repositories.Abstract;
 using Middleware.Models.Domain;
@@ -220,20 +222,26 @@ public class ActionController : ControllerBase
     [ProducesResponseType(typeof(List<RelationModel>), (int)HttpStatusCode.OK)]
     [ProducesResponseType(typeof(ApiResponse), (int)HttpStatusCode.NotFound)]
     [ProducesResponseType(typeof(ApiResponse), (int)HttpStatusCode.InternalServerError)]
-    public async Task<IActionResult> GetRelationAsync(Guid id, string name) //Guid of node and name of relationship
+    public async Task<IActionResult> GetRelationAsync(Guid id, string name, string direction = "Outgoing") //Guid of node and name of relationship
     {
+
         if (string.IsNullOrWhiteSpace(name))
         {
             return BadRequest(new ApiResponse((int) HttpStatusCode.BadRequest, "Relation name not specified"));
         }
-
         if (id == Guid.Empty)
         {
-            return BadRequest(new ApiResponse((int)HttpStatusCode.BadRequest, "Relation name not specified"));
+            return BadRequest(new ApiResponse((int)HttpStatusCode.BadRequest, "Relation ID not specified"));
         }
+        RelationDirection directionEnum;
+        if (Enum.TryParse<RelationDirection>(direction, out directionEnum) == false)
+        {
+            return BadRequest(new ApiResponse((int)HttpStatusCode.BadRequest, "Wrong Relation direction specified"));
+        }
+        var inputDirection = directionEnum;
         try
         {
-            var relations = await _actionRepository.GetRelation(id, name);
+            var relations = await _actionRepository.GetRelation(id, name, inputDirection);
             if (!relations.Any())
             {
                 return NotFound(new ApiResponse((int)HttpStatusCode.NotFound, "Relations were not found."));

--- a/src/RedisInterface/Controllers/CloudController.cs
+++ b/src/RedisInterface/Controllers/CloudController.cs
@@ -1,6 +1,7 @@
 ﻿using System.Net;
 using Microsoft.AspNetCore.Mvc;
 using Middleware.Common.Attributes;
+using Middleware.Common.Enums;
 using Middleware.Common.Responses;
 using Middleware.DataAccess.Repositories.Abstract;
 using Middleware.Models.Domain;
@@ -219,11 +220,25 @@ namespace Middleware.RedisInterface.Controllers
         [ProducesResponseType(typeof(List<RelationModel>), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(ApiResponse), (int)HttpStatusCode.NotFound)]
         [ProducesResponseType(typeof(ApiResponse), (int)HttpStatusCode.InternalServerError)]
-        public async Task<IActionResult> GetRelationAsync(Guid id, string name)
+        public async Task<IActionResult> GetRelationAsync(Guid id, string name, string direction = "Outgoing")
         {
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                return BadRequest(new ApiResponse((int)HttpStatusCode.BadRequest, "Relation name not specified"));
+            }
+            if (id == Guid.Empty)
+            {
+                return BadRequest(new ApiResponse((int)HttpStatusCode.BadRequest, "Relation ID not specified"));
+            }
+            RelationDirection directionEnum;
+            if (Enum.TryParse<RelationDirection>(direction, out directionEnum) == false)
+            {
+                return BadRequest(new ApiResponse((int)HttpStatusCode.BadRequest, "Wrong Relation direction specified"));
+            }
+            var inputDirection = directionEnum;
             try
             {
-                var relations = await _cloudRepository.GetRelation(id, name);
+                var relations = await _cloudRepository.GetRelation(id, name, inputDirection);
                 if (!relations.Any())
                 {
                     return NotFound(new ApiResponse((int)HttpStatusCode.NotFound, "Relations were not found."));

--- a/src/RedisInterface/Controllers/CloudController.cs
+++ b/src/RedisInterface/Controllers/CloudController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Mvc;
 using Middleware.Common.Attributes;
 using Middleware.Common.Enums;
 using Middleware.Common.Responses;
+using Middleware.DataAccess.Repositories;
 using Middleware.DataAccess.Repositories.Abstract;
 using Middleware.Models;
 using Middleware.Models.Domain;
@@ -144,43 +145,7 @@ public class CloudController : ControllerBase
             return StatusCode(statusCode, new ApiResponse(statusCode, $"An error has occurred: {ex.Message}"));
         }
     }
-        /// <summary>
-        /// Retrieves a single relation by name
-        /// </summary>
-        /// <param name="id"></param>
-        /// <param name="name"></param>
-        /// <returns></returns>
-        [HttpGet]
-        [Route("relation/{name}", Name = "CloudGetRelationByName")]
-        [ProducesResponseType(typeof(List<RelationModel>), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(ApiResponse), (int)HttpStatusCode.NotFound)]
-        [ProducesResponseType(typeof(ApiResponse), (int)HttpStatusCode.InternalServerError)]
-        public async Task<IActionResult> GetRelationAsync(Guid id, string name, string direction = "Outgoing")
-        {
-            if (string.IsNullOrWhiteSpace(name))
-            {
-                return BadRequest(new ApiResponse((int)HttpStatusCode.BadRequest, "Relation name not specified"));
-            }
-            if (id == Guid.Empty)
-            {
-                return BadRequest(new ApiResponse((int)HttpStatusCode.BadRequest, "Relation ID not specified"));
-            }
-            RelationDirection directionEnum;
-            if (Enum.TryParse<RelationDirection>(direction, out directionEnum) == false)
-            {
-                return BadRequest(new ApiResponse((int)HttpStatusCode.BadRequest, "Wrong Relation direction specified"));
-            }
-            var inputDirection = directionEnum;
-            try
-            {
-                var relations = await _cloudRepository.GetRelation(id, name, inputDirection);
-                if (!relations.Any())
-                {
-                    return NotFound(new ApiResponse((int)HttpStatusCode.NotFound, "Relations were not found."));
-                }
-                return Ok(relations);
-            }
-            catch (Exception ex)
+        
     /// <summary>
     ///     Delete an CloudModel entity for the given id
     /// </summary>
@@ -241,7 +206,7 @@ public class CloudController : ControllerBase
     }
 
     /// <summary>
-    ///     Retrieves a single relation by name
+    /// Retrieves a single relation by name
     /// </summary>
     /// <param name="id"></param>
     /// <param name="name"></param>
@@ -251,15 +216,31 @@ public class CloudController : ControllerBase
     [ProducesResponseType(typeof(List<RelationModel>), (int)HttpStatusCode.OK)]
     [ProducesResponseType(typeof(ApiResponse), (int)HttpStatusCode.NotFound)]
     [ProducesResponseType(typeof(ApiResponse), (int)HttpStatusCode.InternalServerError)]
-    public async Task<IActionResult> GetRelationAsync(Guid id, string name)
+    public async Task<IActionResult> GetRelationAsync(Guid id, string name, string direction = "Outgoing")
     {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            return BadRequest(new ApiResponse((int)HttpStatusCode.BadRequest, "Relation name not specified"));
+        }
+        if (id == Guid.Empty)
+        {
+            return BadRequest(new ApiResponse((int)HttpStatusCode.BadRequest, "Relation ID not specified"));
+        }
+        RelationDirection directionEnum;
+        if (Enum.TryParse<RelationDirection>(direction, out directionEnum) == false)
+        {
+            return BadRequest(new ApiResponse((int)HttpStatusCode.BadRequest, "Wrong Relation direction specified"));
+        }
+        var inputDirection = directionEnum;
         try
         {
-            var relations = await _locationRepository.GetRelation(id, name);
+            var relations = await _locationRepository.GetRelation(id, name, inputDirection);
             if (!relations.Any())
+            {
                 return NotFound(new ApiResponse((int)HttpStatusCode.NotFound, "Relations were not found."));
+            }
             return Ok(relations);
-        }
+        }        
         catch (Exception ex)
         {
             var statusCode = (int)HttpStatusCode.InternalServerError;

--- a/src/RedisInterface/Controllers/ContainerImageController.cs
+++ b/src/RedisInterface/Controllers/ContainerImageController.cs
@@ -1,6 +1,7 @@
 ﻿using System.Net;
 using Microsoft.AspNetCore.Mvc;
 using Middleware.Common.Attributes;
+using Middleware.Common.Enums;
 using Middleware.Common.Responses;
 using Middleware.DataAccess.Repositories.Abstract;
 using Middleware.Models.Domain;
@@ -227,11 +228,25 @@ namespace Middleware.RedisInterface.Controllers
         [ProducesResponseType(typeof(List<RelationModel>), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(ApiResponse), (int)HttpStatusCode.NotFound)]
         [ProducesResponseType(typeof(ApiResponse), (int)HttpStatusCode.InternalServerError)]
-        public async Task<IActionResult> GetRelationAsync(Guid id, string name)
+        public async Task<IActionResult> GetRelationAsync(Guid id, string name, string direction = "Outgoing")
         {
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                return BadRequest(new ApiResponse((int)HttpStatusCode.BadRequest, "Relation name not specified"));
+            }
+            if (id == Guid.Empty)
+            {
+                return BadRequest(new ApiResponse((int)HttpStatusCode.BadRequest, "Relation ID not specified"));
+            }
+            RelationDirection directionEnum;
+            if (Enum.TryParse<RelationDirection>(direction, out directionEnum) == false)
+            {
+                return BadRequest(new ApiResponse((int)HttpStatusCode.BadRequest, "Wrong Relation direction specified"));
+            }
+            var inputDirection = directionEnum;
             try
             {
-                var relations = await _containerImageRepository.GetRelation(id, name);
+                var relations = await _containerImageRepository.GetRelation(id, name, inputDirection);
                 if (!relations.Any())
                 {
                     return NotFound(new ApiResponse((int)HttpStatusCode.NotFound, "Relations were not found."));

--- a/src/RedisInterface/Controllers/EdgeController.cs
+++ b/src/RedisInterface/Controllers/EdgeController.cs
@@ -262,7 +262,7 @@ public class EdgeController : ControllerBase
             var inputDirection = directionEnum;
             try
             {
-                var relations = await _edgeRepository.GetRelation(id, name, inputDirection);
+                var relations = await _locationRepository.GetRelation(id, name, inputDirection);
                 if (!relations.Any())
                 {
                     return NotFound(new ApiResponse((int)HttpStatusCode.NotFound, "Relations were not found."));

--- a/src/RedisInterface/Controllers/EdgeController.cs
+++ b/src/RedisInterface/Controllers/EdgeController.cs
@@ -1,6 +1,7 @@
 ﻿using System.Net;
 using Microsoft.AspNetCore.Mvc;
 using Middleware.Common.Attributes;
+using Middleware.Common.Enums;
 using Middleware.Common.Responses;
 using Middleware.DataAccess.Repositories.Abstract;
 using Middleware.Models.Domain;
@@ -247,11 +248,25 @@ namespace Middleware.RedisInterface.Controllers
         [ProducesResponseType(typeof(List<RelationModel>), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(ApiResponse), (int)HttpStatusCode.NotFound)]
         [ProducesResponseType(typeof(ApiResponse), (int)HttpStatusCode.InternalServerError)]
-        public async Task<IActionResult> GetRelationAsync(Guid id, string name)
+        public async Task<IActionResult> GetRelationAsync(Guid id, string name, string direction = "Outgoing")
         {
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                return BadRequest(new ApiResponse((int)HttpStatusCode.BadRequest, "Relation name not specified"));
+            }
+            if (id == Guid.Empty)
+            {
+                return BadRequest(new ApiResponse((int)HttpStatusCode.BadRequest, "Relation ID not specified"));
+            }
+            RelationDirection directionEnum;
+            if (Enum.TryParse<RelationDirection>(direction, out directionEnum) == false)
+            {
+                return BadRequest(new ApiResponse((int)HttpStatusCode.BadRequest, "Wrong Relation direction specified"));
+            }
+            var inputDirection = directionEnum;
             try
             {
-                var relations = await _edgeRepository.GetRelation(id, name);
+                var relations = await _edgeRepository.GetRelation(id, name, inputDirection);
                 if (!relations.Any())
                 {
                     return NotFound(new ApiResponse((int)HttpStatusCode.NotFound, "Relations were not found."));

--- a/src/RedisInterface/Controllers/InstanceController.cs
+++ b/src/RedisInterface/Controllers/InstanceController.cs
@@ -1,6 +1,7 @@
 ﻿using System.Net;
 using Microsoft.AspNetCore.Mvc;
 using Middleware.Common.Attributes;
+using Middleware.Common.Enums;
 using Middleware.Common.Responses;
 using Middleware.DataAccess.Repositories.Abstract;
 using Middleware.Models.Domain;
@@ -251,11 +252,25 @@ public class InstanceController : ControllerBase
     [ProducesResponseType(typeof(List<RelationModel>), (int)HttpStatusCode.OK)]
     [ProducesResponseType(typeof(ApiResponse), (int)HttpStatusCode.NotFound)]
     [ProducesResponseType(typeof(ApiResponse), (int)HttpStatusCode.InternalServerError)]
-    public async Task<IActionResult> GetRelationAsync(Guid id, string name)
+    public async Task<IActionResult> GetRelationAsync(Guid id, string name, string direction = "Outgoing")
     {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            return BadRequest(new ApiResponse((int)HttpStatusCode.BadRequest, "Relation name not specified"));
+        }
+        if (id == Guid.Empty)
+        {
+            return BadRequest(new ApiResponse((int)HttpStatusCode.BadRequest, "Relation ID not specified"));
+        }
+        RelationDirection directionEnum;
+        if (Enum.TryParse<RelationDirection>(direction, out directionEnum) == false)
+        {
+            return BadRequest(new ApiResponse((int)HttpStatusCode.BadRequest, "Wrong Relation direction specified"));
+        }
+        var inputDirection = directionEnum;
         try
         {
-            var relations = await _instanceRepository.GetRelation(id, name);
+            var relations = await _instanceRepository.GetRelation(id, name, inputDirection);
             if (!relations.Any())
                 return NotFound(new ApiResponse((int)HttpStatusCode.NotFound, "Relations were not found."));
             return Ok(relations);

--- a/src/RedisInterface/Controllers/LocationController.cs
+++ b/src/RedisInterface/Controllers/LocationController.cs
@@ -1,6 +1,7 @@
 ﻿using System.Net;
 using Microsoft.AspNetCore.Mvc;
 using Middleware.Common.Attributes;
+using Middleware.Common.Enums;
 using Middleware.Common.Responses;
 using Middleware.DataAccess.Repositories.Abstract;
 using Middleware.Models.Domain;
@@ -233,11 +234,25 @@ public class LocationController : ControllerBase
     [ProducesResponseType(typeof(List<RelationModel>), (int)HttpStatusCode.OK)]
     [ProducesResponseType(typeof(ApiResponse), (int)HttpStatusCode.NotFound)]
     [ProducesResponseType(typeof(ApiResponse), (int)HttpStatusCode.InternalServerError)]
-    public async Task<IActionResult> GetRelationAsync(Guid id, string name)
+    public async Task<IActionResult> GetRelationAsync(Guid id, string name, string direction = "Outgoing")
     {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            return BadRequest(new ApiResponse((int)HttpStatusCode.BadRequest, "Relation name not specified"));
+        }
+        if (id == Guid.Empty)
+        {
+            return BadRequest(new ApiResponse((int)HttpStatusCode.BadRequest, "Relation ID not specified"));
+        }
+        RelationDirection directionEnum;
+        if (Enum.TryParse<RelationDirection>(direction, out directionEnum) == false)
+        {
+            return BadRequest(new ApiResponse((int)HttpStatusCode.BadRequest, "Wrong Relation direction specified"));
+        }
+        var inputDirection = directionEnum;
         try
         {
-            var relations = await _locationRepository.GetRelation(id, name);
+            var relations = await _locationRepository.GetRelation(id, name, inputDirection);
             if (!relations.Any())
                 return NotFound(new ApiResponse((int)HttpStatusCode.NotFound, "Relations were not found."));
 

--- a/src/RedisInterface/Controllers/RobotController.cs
+++ b/src/RedisInterface/Controllers/RobotController.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using Microsoft.AspNetCore.Mvc;
 using Middleware.Common.Attributes;
+using Middleware.Common.Enums;
 using Middleware.Common.Responses;
 using Middleware.DataAccess.Repositories.Abstract;
 using Middleware.Models.Domain;
@@ -255,11 +256,25 @@ public class RobotController : ControllerBase
     [ProducesResponseType(typeof(List<RelationModel>), (int)HttpStatusCode.OK)]
     [ProducesResponseType(typeof(ApiResponse), (int)HttpStatusCode.NotFound)]
     [ProducesResponseType(typeof(ApiResponse), (int)HttpStatusCode.InternalServerError)]
-    public async Task<IActionResult> GetRelationAsync(Guid id, string name)
+    public async Task<IActionResult> GetRelationAsync(Guid id, string name, string direction = "Outgoing")
     {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            return BadRequest(new ApiResponse((int)HttpStatusCode.BadRequest, "Relation name not specified"));
+        }
+        if (id == Guid.Empty)
+        {
+            return BadRequest(new ApiResponse((int)HttpStatusCode.BadRequest, "Relation ID not specified"));
+        }
+        RelationDirection directionEnum;
+        if (Enum.TryParse<RelationDirection>(direction, out directionEnum) == false)
+        {
+            return BadRequest(new ApiResponse((int)HttpStatusCode.BadRequest, "Wrong Relation direction specified"));
+        }
+        var inputDirection = directionEnum;
         try
         {
-            var relations = await _robotRepository.GetRelation(id, name);
+            var relations = await _robotRepository.GetRelation(id, name, inputDirection);
             if (!relations.Any())
                 return NotFound(new ApiResponse((int)HttpStatusCode.NotFound, "Relations were not found."));
             return Ok(relations);

--- a/src/RedisInterface/Controllers/TaskController.cs
+++ b/src/RedisInterface/Controllers/TaskController.cs
@@ -1,6 +1,7 @@
 ﻿using System.Net;
 using Microsoft.AspNetCore.Mvc;
 using Middleware.Common.Attributes;
+using Middleware.Common.Enums;
 using Middleware.Common.Responses;
 using Middleware.DataAccess.Repositories.Abstract;
 using Middleware.Models.Domain;
@@ -264,11 +265,25 @@ public class TaskController : ControllerBase
     [ProducesResponseType(typeof(List<RelationModel>), (int)HttpStatusCode.OK)]
     [ProducesResponseType(typeof(ApiResponse), (int)HttpStatusCode.NotFound)]
     [ProducesResponseType(typeof(ApiResponse), (int)HttpStatusCode.InternalServerError)]
-    public async Task<IActionResult> GetRelationAsync(Guid id, string name)
+    public async Task<IActionResult> GetRelationAsync(Guid id, string name, string direction = "Outgoing")
     {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            return BadRequest(new ApiResponse((int)HttpStatusCode.BadRequest, "Relation name not specified"));
+        }
+        if (id == Guid.Empty)
+        {
+            return BadRequest(new ApiResponse((int)HttpStatusCode.BadRequest, "Relation ID not specified"));
+        }
+        RelationDirection directionEnum;
+        if (Enum.TryParse<RelationDirection>(direction, out directionEnum) == false)
+        {
+            return BadRequest(new ApiResponse((int)HttpStatusCode.BadRequest, "Wrong Relation direction specified"));
+        }
+        var inputDirection = directionEnum;
         try
         {
-            var relations = await _taskRepository.GetRelation(id, name);
+            var relations = await _taskRepository.GetRelation(id, name, inputDirection);
             if (!relations.Any())
                 return NotFound(new ApiResponse((int)HttpStatusCode.NotFound, "Relations were not found."));
             return Ok(relations);


### PR DESCRIPTION
# Description

Relations can now be retrieved by their direction, either outgoing or incoming

Fixes #210 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## What has been changed?

- Feature: Relations can be retrieved by their direction


# How Has This Been Tested?

- [x] Tested all endpoints for retrieving relations 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes