### PR TITLE
feat: change property name for enabling/disabling resource reuse

### DIFF
--- a/src/DataAccess/Repositories/Redis/RedisTaskRepository.cs
+++ b/src/DataAccess/Repositories/Redis/RedisTaskRepository.cs
@@ -6,78 +6,43 @@ using RedisGraphDotNet.Client;
 using ILogger = Serilog.ILogger;
 
 
-namespace Middleware.DataAccess.Repositories.Redis
+namespace Middleware.DataAccess.Repositories.Redis;
+
+public class RedisTaskRepository : RedisRepository<TaskModel, TaskDto>, ITaskRepository
 {
-    public class RedisTaskRepository : RedisRepository<TaskModel, TaskDto>, ITaskRepository
+    /// <summary>
+    ///     Default constructor
+    /// </summary>
+    /// <param name="redisClient"></param>
+    /// <param name="redisGraph"></param>
+    /// <param name="logger"></param>
+    public RedisTaskRepository(IRedisConnectionProvider provider, IRedisGraphClient redisGraph, ILogger logger) : base(
+        provider, redisGraph, true, logger)
     {
-        /// <summary>
-        /// Default constructor
-        /// </summary>
-        /// <param name="redisClient"></param>
-        /// <param name="redisGraph"></param>
-        /// <param name="logger"></param>
+    }
 
-        public RedisTaskRepository(IRedisConnectionProvider provider, IRedisGraphClient redisGraph, ILogger logger) : base(provider, redisGraph, true, logger)
-        {
-        }
-
-        /// <summary>
-        /// Patching properties for TaskModel
-        /// </summary>
-        /// <param name="id"></param>
-        /// <param name="patch"></param>
-        /// <returns> Patched model </returns>
-        public async Task<TaskModel> PatchTaskAsync(Guid id, TaskModel patch)
-        {
-            TaskModel? currentModel = await GetByIdAsync(id);
-            if (currentModel == null)
-            {
-                return null;
-            }
-            if (!string.IsNullOrEmpty(patch.Name))
-            {
-                currentModel.Name = patch.Name;
-            }
-            if (patch.ReplanActionPlannerLocked != null)
-            {
-                currentModel.ReplanActionPlannerLocked = patch.ReplanActionPlannerLocked;
-            }
-            if (patch.ResourceLock != null)
-            {
-                currentModel.ResourceLock = patch.ResourceLock;
-            }
-            if (!string.IsNullOrEmpty(patch.TaskPriority.ToString()))
-            {
-                currentModel.TaskPriority = patch.TaskPriority;
-            }
-            if (patch.FullReplan != null)
-            {
-                currentModel.FullReplan = patch.FullReplan;
-            }
-            if (patch.PartialRePlan != null)
-            {
-                currentModel.PartialRePlan = patch.PartialRePlan;
-            }
-            if (patch.DeterministicTask != null)
-            {
-                currentModel.DeterministicTask = patch.DeterministicTask;
-            }
-            if (patch.MarkovianProcess != null)
-            {
-                currentModel.MarkovianProcess = patch.MarkovianProcess;
-            }
-            if (patch.ActionSequence != null)
-            {
-                currentModel.ActionSequence = patch.ActionSequence;
-            }
-            if (patch.Tags != null)
-            {
-                currentModel.Tags = patch.Tags;
-            }
-            await UpdateAsync(currentModel);
-            return currentModel;
-
-        }
-
+    /// <summary>
+    ///     Patching properties for TaskModel
+    /// </summary>
+    /// <param name="id"></param>
+    /// <param name="patch"></param>
+    /// <returns> Patched model </returns>
+    public async Task<TaskModel> PatchTaskAsync(Guid id, TaskModel patch)
+    {
+        var currentModel = await GetByIdAsync(id);
+        if (currentModel == null) return null;
+        if (!string.IsNullOrEmpty(patch.Name)) currentModel.Name = patch.Name;
+        if (patch.ReplanActionPlannerLocked != null)
+            currentModel.ReplanActionPlannerLocked = patch.ReplanActionPlannerLocked;
+        if (patch.DisableResourceReuse != null) currentModel.DisableResourceReuse = patch.DisableResourceReuse;
+        if (!string.IsNullOrEmpty(patch.TaskPriority.ToString())) currentModel.TaskPriority = patch.TaskPriority;
+        if (patch.FullReplan != null) currentModel.FullReplan = patch.FullReplan;
+        if (patch.PartialRePlan != null) currentModel.PartialRePlan = patch.PartialRePlan;
+        if (patch.DeterministicTask != null) currentModel.DeterministicTask = patch.DeterministicTask;
+        if (patch.MarkovianProcess != null) currentModel.MarkovianProcess = patch.MarkovianProcess;
+        if (patch.ActionSequence != null) currentModel.ActionSequence = patch.ActionSequence;
+        if (patch.Tags != null) currentModel.Tags = patch.Tags;
+        await UpdateAsync(currentModel);
+        return currentModel;
     }
 }

--- a/src/Models/Domain/TaskModel.cs
+++ b/src/Models/Domain/TaskModel.cs
@@ -22,8 +22,8 @@ public class TaskModel : BaseModel
     ///     Should the resources be limited to the current deployment location
     ///     and should skip the reuse of the existing resources
     /// </summary>
-    [JsonPropertyName("ResourceLock")]
-    public bool ResourceLock { get; set; }
+    [JsonPropertyName("DisableResourceReuse")]
+    public bool DisableResourceReuse { get; set; }
 
     [JsonPropertyName("TaskPriority")]
     public int TaskPriority { get; set; }

--- a/src/ResourcePlanner/ResourcePlanner.cs
+++ b/src/ResourcePlanner/ResourcePlanner.cs
@@ -67,7 +67,7 @@ internal class ResourcePlanner : IResourcePlanner
                 var instanceResp = await _redisInterfaceClient.InstanceGetByIdAsync(relation.PointsTo.Id);
                 var instance = instanceResp.ToInstance();
 
-                if (instance.CanBeReused() && taskModel.ResourceLock)
+                if (instance.CanBeReused() && !taskModel.DisableResourceReuse)
                 {
                     var reusedInstance = await GetInstanceToReuse(instance, orchestratorApiClient);
                     if (reusedInstance is not null)
@@ -520,7 +520,7 @@ internal class ResourcePlanner : IResourcePlanner
                     await _redisInterfaceClient.InstanceGetByIdAsync(relation.PointsTo.Id);
                 var instance = instanceResponse.ToInstance();
 
-                if (instance.CanBeReused() && taskModel.ResourceLock)
+                if (instance.CanBeReused() && !taskModel.DisableResourceReuse)
                 {
                     var reusedInstance = await GetInstanceToReuse(instance, orchestratorApiClient);
                     if (reusedInstance is not null)

--- a/src/TaskPlanner/Contracts/Requests/CreatePlanRequest.cs
+++ b/src/TaskPlanner/Contracts/Requests/CreatePlanRequest.cs
@@ -8,10 +8,11 @@ public class CreatePlanRequest
     [JsonPropertyName("RobotId")]
     public Guid RobotId { get; set; }
 
-    [JsonPropertyName("LockResourceReUse")]
-    public bool LockResourceReUse { get; set; } //TODO: check only the instances that are avialable in the local middleware
+    [JsonPropertyName("DisableResourceReuse")]
+    public bool DisableResourceReuse { get; set; } = false;
+
     /// <summary>
-    /// only change the instance placement in the existing plan during a replan
+    ///     only change the instance placement in the existing plan during a replan
     /// </summary>
     [JsonPropertyName("ReplanActionPlannerLocked")]
     public bool ReplanActionPlannerLocked { get; set; }
@@ -20,13 +21,13 @@ public class CreatePlanRequest
     public Guid Id { get; set; }
 
     [JsonPropertyName("TaskDescription")]
-    public String TaskDescription { get; set; }
-        
+    public string TaskDescription { get; set; }
+
     /// <summary>
-    /// Use the hardcoded action plan if true, use the semantic planning if false
-    /// </summary>        
+    ///     Use the hardcoded action plan if true, use the semantic planning if false
+    /// </summary>
     [JsonPropertyName("ContextKnown")]
-    public bool ContextKnown { get; set; } = true; 
+    public bool ContextKnown { get; set; } = true;
 
     [JsonPropertyName("Questions")]
     public List<DialogueModel> Questions { get; set; }

--- a/src/TaskPlanner/Contracts/Requests/CreateRePlanRequest.cs
+++ b/src/TaskPlanner/Contracts/Requests/CreateRePlanRequest.cs
@@ -3,12 +3,12 @@ using Middleware.Models.Domain;
 
 namespace Middleware.TaskPlanner.Contracts.Requests;
 
-public class CreateRePlanRequest 
+public class CreateRePlanRequest
 {
     [JsonPropertyName("RobotId")]
     public Guid RobotId { get; set; }
 
-    [JsonPropertyName("LockResourceReUse")]
+    [JsonPropertyName("DisableResourceReuse")]
     public bool LockResourceReUse { get; set; }
 
     [JsonPropertyName("ContextKnown")]
@@ -22,5 +22,4 @@ public class CreateRePlanRequest
 
     [JsonPropertyName("Questions")]
     public List<DialogueModel> Questions { get; set; }
-
 }

--- a/src/TaskPlanner/Controllers/PlanController.cs
+++ b/src/TaskPlanner/Controllers/PlanController.cs
@@ -50,7 +50,7 @@ public class PlanController : ControllerBase
         }
 
         var id = inputModel.Id;
-        var lockResource = inputModel.LockResourceReUse;
+        var lockResource = inputModel.DisableResourceReuse;
         var robotId = inputModel.RobotId;
 
         try
@@ -59,7 +59,7 @@ public class PlanController : ControllerBase
 
             var (plan, robot2) =
                 await _actionPlanner.Plan(id, robotId);
-            plan.ResourceLock = lockResource;
+            plan.DisableResourceReuse = lockResource;
 
             var resourcePlan = await _publishService.RequestResourcePlan(plan, robot2);
 
@@ -118,7 +118,7 @@ public class PlanController : ControllerBase
         }
 
         var id = inputModel.Id; //task id
-        var lockResource = inputModel.LockResourceReUse;
+        var lockResource = inputModel.DisableResourceReuse;
         var robotId = inputModel.RobotId; //robot id
         var contextKnown = inputModel.ContextKnown;
         var dialogueTemp = inputModel.Questions;

--- a/src/TaskPlanner/Services/ActionPlanner.cs
+++ b/src/TaskPlanner/Services/ActionPlanner.cs
@@ -112,7 +112,7 @@ public class ActionPlanner : IActionPlanner
         var MarkovianProcess = oldTask.MarkovianProcess;
         var currentTaskId = oldTask.Id;
         var currentPlanId = oldTask.ActionPlanId;
-        var resourceLock = oldTask.ResourceLock;
+        var resourceLock = oldTask.DisableResourceReuse;
         var ActionReplanLocked = oldTask.ReplanActionPlannerLocked;
         var oldActionSequence = oldTask.ActionSequence;
         var FinalCandidatesActions = new List<ActionModel>();
@@ -563,7 +563,7 @@ public class ActionPlanner : IActionPlanner
         }
 
         task.ActionSequence = ActionSequence;
-        task.ResourceLock = resourceLock;
+        task.DisableResourceReuse = resourceLock;
         return new(task, robot);
     }
 }


### PR DESCRIPTION
# Description

Renamed the property and parameter `LockResourceReuse` to have a clearer meaning: `DisableResourceReuse`. From now on, resource reuse will be enabled by default. 

Fixes #246 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## What has been changed?

This section lists what has been changed with this pull request. Each entry lists the type of change introduced in the following order:

1. Feature: Enabled resource reuse by default
2. Fix: Confusing name of the request plan parameter

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes