### PR TITLE
feat: allow heartbeat expiration to be configured from db

### DIFF
--- a/src/CentralApi/Jobs/UpdateOnlineLocationJob.cs
+++ b/src/CentralApi/Jobs/UpdateOnlineLocationJob.cs
@@ -2,55 +2,63 @@
 using Middleware.DataAccess.Repositories.Abstract;
 using Middleware.Models.Domain;
 using Quartz;
-using KeyValuePair = Middleware.Models.Domain.KeyValuePair;
 
 namespace Middleware.CentralApi.Jobs;
+
 [DisallowConcurrentExecution]
 public class UpdateOnlineLocationJob : BaseJob<UpdateOnlineStatusJob>
 {
     private readonly ILogger _logger;
     private readonly IRobotRepository _robotRepository;
-    public UpdateOnlineLocationJob(ILogger<UpdateOnlineStatusJob> logger, IRobotRepository robotRepository) : base(logger)
+    private readonly ISystemConfigRepository _systemConfig;
+
+    public UpdateOnlineLocationJob(ILogger<UpdateOnlineStatusJob> logger, IRobotRepository robotRepository,
+        ISystemConfigRepository systemConfig) : base(logger)
     {
         _logger = logger;
         _robotRepository = robotRepository;
+        _systemConfig = systemConfig;
     }
 
     protected override async Task ExecuteJobAsync(IJobExecutionContext context)
     {
+        var cfg = await _systemConfig.GetConfigAsync();
+        if (cfg is null) throw new ArgumentException("No system config was found");
 
+        var heartbeatExpiration = cfg.HeartbeatExpirationInMinutes;
         // get all CAN_REACH relations
         var relations = new List<RelationModel>();
         try
         {
             relations = await _robotRepository.GetRelationsWithName("CAN_REACH");
-        } catch (Exception ex)
+        }
+        catch (Exception ex)
         {
             Logger.LogError(ex, "There was en error while getting relations: CAN_REACH;");
         }
 
         if (relations.Any())
-            // chech all relations
+            // check all relations
+        {
             foreach (var rel in relations)
             {
-
-                var relationAttributes = new List<KeyValuePair>();
-                relationAttributes = rel.RelationAttributes;
+                var relationAttributes = rel.RelationAttributes;
                 var robotId = rel.InitiatesFrom.Id;
                 var locationId = rel.PointsTo.Id;
                 if (relationAttributes != null)
-                    foreach (KeyValuePair relAtribut in relationAttributes)
+                {
+                    foreach (var relAttribute in relationAttributes)
                     {
-                        if (relAtribut.Key == "lastUpdatedTime")
+                        if (relAttribute.Key == "lastUpdatedTime")
                         {
-                            string dateInput = (string)relAtribut.Value;
+                            var dateInput = (string)relAttribute.Value;
                             var parsedDateTime = DateTime.Parse(dateInput);
 
-                            DateTime threeMinutesEarlier = DateTime.UtcNow.AddMinutes(-3);
-                            // Check if last updated time was no later then 3 minutes ago from now.
+                            var threeMinutesEarlier = DateTime.UtcNow.AddMinutes(-1 * heartbeatExpiration);
+                            // Check if last updated time was no later than 3 minutes ago from now.
                             if (parsedDateTime < threeMinutesEarlier)
                             {
-                                RelationModel relationModel = new RelationModel();
+                                var relationModel = new RelationModel();
                                 var relationName = rel.RelationName;
                                 relationModel.InitiatesFrom.Id = robotId;
                                 relationModel.InitiatesFrom.Type = rel.InitiatesFrom.Type;
@@ -62,17 +70,23 @@ public class UpdateOnlineLocationJob : BaseJob<UpdateOnlineStatusJob>
                                     var isValid = await _robotRepository.DeleteRelationAsync(relationModel);
                                     if (!isValid)
                                     {
-                                        Logger.LogError("Deleting relation did not succeed: formId: {robotId} relationName: {name} toId:{Id2}", robotId, relationName, locationId);
+                                        Logger.LogError(
+                                            "Deleting relation did not succeed: formId: {robotId} relationName: {name} toId:{Id2}",
+                                            robotId, relationName, locationId);
                                     }
                                 }
                                 catch (Exception ex)
                                 {
-                                    Logger.LogError(ex, "There was en error while deleteing relation formId: {robotId} relationName: {name} toId:{Id2}", robotId, relationName, locationId);
+                                    Logger.LogError(ex,
+                                        "There was en error while deleting relation formId: {robotId} relationName: {name} toId:{Id2}",
+                                        robotId, relationName, locationId);
                                     //throw new ArgumentException("The relation was not deleted", nameof(model));
                                 }
                             }
                         }
                     }
+                }
             }
+        }
     }
 }

--- a/src/CentralApi/Jobs/UpdateOnlineStatusJob.cs
+++ b/src/CentralApi/Jobs/UpdateOnlineStatusJob.cs
@@ -11,8 +11,7 @@ public class UpdateOnlineStatusJob : BaseJob<UpdateOnlineStatusJob>
     private readonly ISystemConfigRepository _systemConfig;
 
     public UpdateOnlineStatusJob(ILogger<UpdateOnlineStatusJob> logger, ILocationRepository locationRepository,
-        ISystemConfigRepository systemConfig) :
-        base(logger)
+        ISystemConfigRepository systemConfig) : base(logger)
     {
         _locationRepository = locationRepository;
         _systemConfig = systemConfig;
@@ -33,20 +32,20 @@ public class UpdateOnlineStatusJob : BaseJob<UpdateOnlineStatusJob>
                 if (!loc.IsOnline)
                     continue;
 
-                var threeMinutesEarlier = DateTime.UtcNow.AddMinutes(-1 * heartbeatExpiration);
-                // Check if last updated time was no later than 3 minutes ago from now.
-                if (loc.LastUpdatedTime < threeMinutesEarlier)
+                var xMinutesAgo = DateTime.UtcNow.AddMinutes(-1 * heartbeatExpiration);
+                // Check if last updated time was no later than X minutes ago from now.
+                if (loc.LastUpdatedTime >= xMinutesAgo)
+                    continue;
+
+                try
                 {
-                    try
-                    {
-                        await _locationRepository.SetCloudOnlineStatusAsync(loc.Id, false);
-                    }
-                    catch (Exception ex)
-                    {
-                        Logger.LogError(ex,
-                            "There was en error while updating the status of the cloud: {Id}",
-                            loc.Id);
-                    }
+                    await _locationRepository.SetCloudOnlineStatusAsync(loc.Id, false);
+                }
+                catch (Exception ex)
+                {
+                    Logger.LogError(ex,
+                        "There was en error while updating the status of the cloud: {Id}",
+                        loc.Id);
                 }
             }
         }

--- a/src/DataAccess/ExtensionMethods/DataAccessExtensionMethods.cs
+++ b/src/DataAccess/ExtensionMethods/DataAccessExtensionMethods.cs
@@ -52,16 +52,16 @@ public static class DataAccessExtensionMethods
         services.AddScoped<ISystemConfigRepository, SystemConfigRepository>();
         services.AddScoped<ILocationRepository, RedisLocationRepository>();
 
-
         return services;
     }
+
     public static IServiceCollection RegisterCentralApiRepositories(this IServiceCollection services)
     {
         services.AddScoped<ICloudRepository, RedisCloudRepository>();
         services.AddScoped<IEdgeRepository, RedisEdgeRepository>();
         services.AddScoped<IRobotRepository, RedisRobotRepository>();
         services.AddScoped<ILocationRepository, RedisLocationRepository>();
-
+        services.AddScoped<ISystemConfigRepository, SystemConfigRepository>();
         return services;
     }
 }

--- a/src/Models/Domain/SystemConfigModel.cs
+++ b/src/Models/Domain/SystemConfigModel.cs
@@ -13,6 +13,7 @@ public class SystemConfigModel : BaseModel
     public string Ros2RelayContainer { get; set; } = default!;
     public string Ros1RelayContainer { get; set; } = default!;
     public string RosInterRelayNetAppContainer { get; set; } = default!;
+    public int HeartbeatExpirationInMinutes { get; set; }
 
     /// <inheritdoc />
     public override Dto.Dto ToDto()
@@ -23,7 +24,8 @@ public class SystemConfigModel : BaseModel
             Id = d.Id.ToString(),
             Ros1RelayContainer = d.Ros1RelayContainer,
             Ros2RelayContainer = d.Ros2RelayContainer,
-            RosInterRelayNetAppContainer = d.RosInterRelayNetAppContainer
+            RosInterRelayNetAppContainer = d.RosInterRelayNetAppContainer,
+            HeartbeatExpirationInMinutes = d.HeartbeatExpirationInMinutes
         };
     }
 }

--- a/src/Models/Dto/SystemConfigDto.cs
+++ b/src/Models/Dto/SystemConfigDto.cs
@@ -22,6 +22,9 @@ public class SystemConfigDto : Dto
     [Indexed]
     public string RosInterRelayNetAppContainer { get; init; } = default!;
 
+    [Indexed]
+    public int HeartbeatExpirationInMinutes { get; set; }
+
     /// <inheritdoc />
     public override BaseModel ToModel()
     {
@@ -32,7 +35,8 @@ public class SystemConfigDto : Dto
             Name = "System Config",
             Ros1RelayContainer = d.Ros1RelayContainer,
             Ros2RelayContainer = d.Ros2RelayContainer,
-            RosInterRelayNetAppContainer = d.RosInterRelayNetAppContainer
+            RosInterRelayNetAppContainer = d.RosInterRelayNetAppContainer,
+            HeartbeatExpirationInMinutes = d.HeartbeatExpirationInMinutes
         };
     }
 }

--- a/src/Orchestrator/Installer/StartupDataInstaller.cs
+++ b/src/Orchestrator/Installer/StartupDataInstaller.cs
@@ -75,6 +75,12 @@ internal class StartupDataInstaller : IStartupDataInstaller
             cfg.RosInterRelayNetAppContainer = defaultCfg.RosInterRelayNetAppContainer;
         }
 
+        if (cfg.HeartbeatExpirationInMinutes == default)
+        {
+            isCorrect = false;
+            cfg.HeartbeatExpirationInMinutes = defaultCfg.HeartbeatExpirationInMinutes;
+        }
+
         return isCorrect;
     }
 
@@ -84,9 +90,9 @@ internal class StartupDataInstaller : IStartupDataInstaller
         {
             Ros1RelayContainer = "but5gera/relay_network_application:0.4.4",
             Ros2RelayContainer = "but5gera/ros2_relay_server:0.1.0",
-            RosInterRelayNetAppContainer = "but5gera/inter_relay_network_application:0.4.4"
+            RosInterRelayNetAppContainer = "but5gera/inter_relay_network_application:0.4.4",
+            HeartbeatExpirationInMinutes = 3
         };
-
 
         return cfg;
     }


### PR DESCRIPTION
# Description

This feature allows the heartbeat expiration to be configured from DB. Adds a new entry to the system config repository and uses it in the heartbeat quartz jobs.


Fixes #234 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## What has been changed?

This section lists what has been changed with this pull request. Each entry lists the type of change introduced in the following order:
1. Feature: heartbeat expiration is now configurable from the database level

# How Has This Been Tested?

- [ ] Started CentralApi and run the quartz jobs
- [ ] Verified that new config entry is saved in the DB

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes