### PR TITLE
fix: check for duplicate names when adding new object

### DIFF
--- a/src/DataAccess/Repositories/Abstract/IActionRepository.cs
+++ b/src/DataAccess/Repositories/Abstract/IActionRepository.cs
@@ -1,8 +1,9 @@
 ﻿using Middleware.Models.Domain;
+using Middleware.Models.Dto;
 
 namespace Middleware.DataAccess.Repositories.Abstract
 {
-    public interface IActionRepository : IBaseRepository<ActionModel>, IRelationRepository
+    public interface IActionRepository : IRedisRepository<ActionModel, ActionDto>
     {
         Task<ActionModel> PatchActionAsync(Guid id, ActionModel patch);
 

--- a/src/DataAccess/Repositories/Abstract/IContainerImageRepository.cs
+++ b/src/DataAccess/Repositories/Abstract/IContainerImageRepository.cs
@@ -1,8 +1,9 @@
 ﻿using Middleware.Models.Domain;
+using Middleware.Models.Dto;
 
 namespace Middleware.DataAccess.Repositories.Abstract
 {
-    public interface IContainerImageRepository : IBaseRepository<ContainerImageModel>, IRelationRepository
+    public interface IContainerImageRepository : IRedisRepository<ContainerImageModel, ContainerImageDto>
     {
         Task<ContainerImageModel> PatchContainerImageAsync(Guid id, ContainerImageModel patch);
         /// <summary>

--- a/src/DataAccess/Repositories/Abstract/IInstanceRepository.cs
+++ b/src/DataAccess/Repositories/Abstract/IInstanceRepository.cs
@@ -1,8 +1,9 @@
 ﻿using Middleware.Models.Domain;
+using Middleware.Models.Dto;
 
 namespace Middleware.DataAccess.Repositories.Abstract
 {
-    public interface IInstanceRepository : IBaseRepository<InstanceModel>, IRelationRepository
+    public interface IInstanceRepository : IRedisRepository<InstanceModel, InstanceDto>
     {
         Task<InstanceModel> PatchInstanceAsync(Guid id, InstanceModel patch);
 

--- a/src/DataAccess/Repositories/Abstract/IRobotRepository.cs
+++ b/src/DataAccess/Repositories/Abstract/IRobotRepository.cs
@@ -1,8 +1,9 @@
 ﻿using Middleware.Models.Domain;
+using Middleware.Models.Dto;
 
 namespace Middleware.DataAccess.Repositories.Abstract
 {
-    public interface IRobotRepository : IBaseRepository<RobotModel>, IRelationRepository
+    public interface IRobotRepository : IRedisRepository<RobotModel, RobotDto>
     {
         Task<RobotModel> PatchRobotAsync(Guid id, RobotModel patch);
 

--- a/src/DataAccess/Repositories/Abstract/ITaskRepository.cs
+++ b/src/DataAccess/Repositories/Abstract/ITaskRepository.cs
@@ -1,8 +1,10 @@
 ﻿using Middleware.Models.Domain;
+using Middleware.Models.Dto;
+using StackExchange.Redis;
 
 namespace Middleware.DataAccess.Repositories.Abstract
 {
-    public interface ITaskRepository : IBaseRepository<TaskModel>, IRelationRepository
+    public interface ITaskRepository : IRedisRepository<TaskModel, TaskDto>
     {
         Task<TaskModel> PatchTaskAsync(Guid id, TaskModel patch);
     }

--- a/src/DataAccess/Repositories/ActionRepository.cs
+++ b/src/DataAccess/Repositories/ActionRepository.cs
@@ -1,9 +1,12 @@
-﻿using System.Text.Json;
+﻿using System.Linq.Expressions;
+using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using Middleware.DataAccess.Repositories.Abstract;
 using Middleware.Models.Domain;
+using Middleware.Models.Dto;
 using Middleware.Models.Enums;
 using NReJSON;
+using Redis.OM.Searching;
 using RedisGraphDotNet.Client;
 using StackExchange.Redis;
 
@@ -54,6 +57,30 @@ namespace Middleware.DataAccess.Repositories
             }
             await Db.JsonSetAsync(id.ToString(), JsonSerializer.Serialize(currentModel));
             return currentModel;
+        }
+
+        /// <inheritdoc />
+        public Task DeleteAsync(ActionModel model)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public Task<List<ActionModel>> FindAsync(Expression<Func<ActionDto, bool>> predicate)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public Task<ActionModel?> FindSingleAsync(Expression<Func<ActionDto, bool>> predicate)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public IRedisCollection<ActionDto> FindQuery(Expression<Func<ActionDto, bool>> predicate)
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/src/DataAccess/Repositories/ContainerImageRepository.cs
+++ b/src/DataAccess/Repositories/ContainerImageRepository.cs
@@ -1,9 +1,12 @@
+using System.Linq.Expressions;
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using Middleware.DataAccess.Repositories.Abstract;
 using Middleware.Models.Domain;
+using Middleware.Models.Dto;
 using Middleware.Models.Enums;
 using NReJSON;
+using Redis.OM.Searching;
 using RedisGraphDotNet.Client;
 using StackExchange.Redis;
 
@@ -78,6 +81,30 @@ namespace Middleware.DataAccess.Repositories
             }
 
             return images;
+        }
+
+        /// <inheritdoc />
+        public Task DeleteAsync(ContainerImageModel model)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public Task<List<ContainerImageModel>> FindAsync(Expression<Func<ContainerImageDto, bool>> predicate)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public Task<ContainerImageModel?> FindSingleAsync(Expression<Func<ContainerImageDto, bool>> predicate)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public IRedisCollection<ContainerImageDto> FindQuery(Expression<Func<ContainerImageDto, bool>> predicate)
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/src/DataAccess/Repositories/InstanceRepository.cs
+++ b/src/DataAccess/Repositories/InstanceRepository.cs
@@ -1,9 +1,12 @@
-﻿using System.Text.Json;
+﻿using System.Linq.Expressions;
+using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using Middleware.DataAccess.Repositories.Abstract;
 using Middleware.Models.Domain;
+using Middleware.Models.Dto;
 using Middleware.Models.Enums;
 using NReJSON;
+using Redis.OM.Searching;
 using RedisGraphDotNet.Client;
 using StackExchange.Redis;
 
@@ -64,5 +67,29 @@ public class InstanceRepository : BaseRepository<InstanceModel>, IInstanceReposi
         }
 
         return instanceCandidatesFinal.FirstOrDefault();
+    }
+
+    /// <inheritdoc />
+    public Task DeleteAsync(InstanceModel model)
+    {
+        throw new NotImplementedException();
+    }
+
+    /// <inheritdoc />
+    public Task<List<InstanceModel>> FindAsync(Expression<Func<InstanceDto, bool>> predicate)
+    {
+        throw new NotImplementedException();
+    }
+
+    /// <inheritdoc />
+    public Task<InstanceModel?> FindSingleAsync(Expression<Func<InstanceDto, bool>> predicate)
+    {
+        throw new NotImplementedException();
+    }
+
+    /// <inheritdoc />
+    public IRedisCollection<InstanceDto> FindQuery(Expression<Func<InstanceDto, bool>> predicate)
+    {
+        throw new NotImplementedException();
     }
 }

--- a/src/DataAccess/Repositories/RobotRepository.cs
+++ b/src/DataAccess/Repositories/RobotRepository.cs
@@ -1,9 +1,12 @@
-﻿using System.Text.Json;
+﻿using System.Linq.Expressions;
+using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using Middleware.DataAccess.Repositories.Abstract;
 using Middleware.Models.Domain;
+using Middleware.Models.Dto;
 using Middleware.Models.Enums;
 using NReJSON;
+using Redis.OM.Searching;
 using RedisGraphDotNet.Client;
 using StackExchange.Redis;
 
@@ -143,5 +146,28 @@ namespace Middleware.DataAccess.Repositories
             return clouds;
         }
 
+        /// <inheritdoc />
+        public Task DeleteAsync(RobotModel model)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public Task<List<RobotModel>> FindAsync(Expression<Func<RobotDto, bool>> predicate)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public Task<RobotModel?> FindSingleAsync(Expression<Func<RobotDto, bool>> predicate)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public IRedisCollection<RobotDto> FindQuery(Expression<Func<RobotDto, bool>> predicate)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/DataAccess/Repositories/TaskRepository.cs
+++ b/src/DataAccess/Repositories/TaskRepository.cs
@@ -1,9 +1,12 @@
-﻿using System.Text.Json;
+﻿using System.Linq.Expressions;
+using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using Middleware.DataAccess.Repositories.Abstract;
 using Middleware.Models.Domain;
+using Middleware.Models.Dto;
 using Middleware.Models.Enums;
 using NReJSON;
+using Redis.OM.Searching;
 using RedisGraphDotNet.Client;
 using StackExchange.Redis;
 
@@ -46,6 +49,30 @@ namespace Middleware.DataAccess.Repositories
             await Db.JsonSetAsync(id.ToString(), JsonSerializer.Serialize(currentModel));
             return currentModel;
 
+        }
+
+        /// <inheritdoc />
+        public Task DeleteAsync(TaskModel model)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public Task<List<TaskModel>> FindAsync(Expression<Func<TaskDto, bool>> predicate)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public Task<TaskModel?> FindSingleAsync(Expression<Func<TaskDto, bool>> predicate)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public IRedisCollection<TaskDto> FindQuery(Expression<Func<TaskDto, bool>> predicate)
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/src/Orchestrator/Deployment/DeploymentService.cs
+++ b/src/Orchestrator/Deployment/DeploymentService.cs
@@ -89,31 +89,6 @@ internal class DeploymentService : IDeploymentService
         var retVal = true;
         try
         {
-            //Delete the LOCATED_AT relationships between instance and edge/cloud.
-            // TODO: refactor so RedisInterfaceClient can take ILocation as parameter to adding the relation
-            var actionTempList = actionPlan.ActionSequence;
-            // foreach (var action in actionTempList!)
-            // {
-            //     BaseModel placement;
-            //     if (action.PlacementType!.ToUpper().Contains("CLOUD"))
-            //     {
-            //         var cloud = (await _redisInterfaceClient.GetCloudByNameAsync(action.Placement!))?.ToCloud();
-            //         placement = cloud;
-            //     }
-            //     else
-            //     {
-            //         var edge = (await _redisInterfaceClient.GetEdgeByNameAsync(action.Placement!)).ToEdge();
-            //         placement = edge;
-            //     }
-            //
-            //     if (placement is null) continue;
-            //     foreach (var instance in action.Services)
-            //     {
-            //         //delete all the located_at relationships between all instances of 1 action and the resources been edge/cloud
-            //         await _redisInterfaceClient.DeleteRelationAsync(instance, placement, "LOCATED_AT");
-            //     }
-            // }
-
             foreach (var action in actionPlan.ActionSequence!)
             {
                 var relayShouldBeDeleted = true;

--- a/src/RedisInterface/Controllers/ActionController.cs
+++ b/src/RedisInterface/Controllers/ActionController.cs
@@ -104,6 +104,13 @@ public class ActionController : ControllerBase
     {
         try
         {
+            var existingTask = await _actionRepository.FindSingleAsync(t=>t.Name == request.Name);
+            if (existingTask is not null)
+            {
+                return StatusCode((int)HttpStatusCode.BadRequest,
+                    new ApiResponse((int)HttpStatusCode.BadRequest,
+                        "Action with specified name already exists"));
+            }
             var action  = await _actionService.AddAsync(request.ToAction());
             return Ok(action.ToActionResponse());
         }

--- a/src/RedisInterface/Controllers/CloudController.cs
+++ b/src/RedisInterface/Controllers/CloudController.cs
@@ -102,6 +102,13 @@ public class CloudController : ControllerBase
         if (model == null) return BadRequest("Parameters were not specified.");
         try
         {
+            var existingLoc = await _locationRepository.GetByNameAsync(model.Name);
+            if (existingLoc is not null)
+            {
+                return StatusCode((int)HttpStatusCode.BadRequest,
+                    new ApiResponse((int)HttpStatusCode.BadRequest,
+                        "Location with specified name already exists"));
+            }
             var location = await _locationRepository.AddAsync(model.ToLocation());
             if (location is null)
             {

--- a/src/RedisInterface/Controllers/ContainerImageController.cs
+++ b/src/RedisInterface/Controllers/ContainerImageController.cs
@@ -100,6 +100,13 @@ namespace Middleware.RedisInterface.Controllers
             try
             {
                 var model = request.ToContainer();
+                var existingLoc = await _containerImageRepository.FindSingleAsync(c=>c.Name == model.Name);
+                if (existingLoc is not null)
+                {
+                    return StatusCode((int)HttpStatusCode.BadRequest,
+                        new ApiResponse((int)HttpStatusCode.BadRequest,
+                            "ContainerImage with specified name already exists"));
+                }
                 ContainerImageModel cim = await _containerImageRepository.AddAsync(model);
                 if (cim is null)
                 {

--- a/src/RedisInterface/Controllers/EdgeController.cs
+++ b/src/RedisInterface/Controllers/EdgeController.cs
@@ -102,6 +102,13 @@ public class EdgeController : ControllerBase
         try
         {
             var model = request.ToLocation();
+            var existingLoc = await _locationRepository.GetByNameAsync(model.Name);
+            if (existingLoc is not null)
+            {
+                return StatusCode((int)HttpStatusCode.BadRequest,
+                    new ApiResponse((int)HttpStatusCode.BadRequest,
+                        "Location with specified name already exists"));
+            }
             var edge = await _locationRepository.AddAsync(model);
             if (edge is null)
             {

--- a/src/RedisInterface/Controllers/InstanceController.cs
+++ b/src/RedisInterface/Controllers/InstanceController.cs
@@ -96,6 +96,13 @@ public class InstanceController : ControllerBase
         try
         {
             var model = request.ToInstance();
+            var existingInstance = await _instanceRepository.FindSingleAsync(i=>i.Name == model.Name);
+            if (existingInstance is not null)
+            {
+                return StatusCode((int)HttpStatusCode.BadRequest,
+                    new ApiResponse((int)HttpStatusCode.BadRequest,
+                        "Instance with specified name already exists"));
+            }
             var instance = await _instanceRepository.AddAsync(model);
             if (instance is null)
             {

--- a/src/RedisInterface/Controllers/LocationController.cs
+++ b/src/RedisInterface/Controllers/LocationController.cs
@@ -98,6 +98,13 @@ public class LocationController : ControllerBase
         try
         {
             var model = request.ToLocation();
+            var existingLoc = await _locationRepository.GetByNameAsync(model.Name);
+            if (existingLoc is not null)
+            {
+                return StatusCode((int)HttpStatusCode.BadRequest,
+                    new ApiResponse((int)HttpStatusCode.BadRequest,
+                        "Location with specified name already exists"));
+            }
             var location = await _locationRepository.AddAsync(model);
             if (location is null)
             {

--- a/src/RedisInterface/Controllers/RobotController.cs
+++ b/src/RedisInterface/Controllers/RobotController.cs
@@ -97,6 +97,13 @@ public class RobotController : ControllerBase
         try
         {
             var model = request.ToRobot();
+            var existingRobot = await _robotRepository.FindSingleAsync(r=>r.Name == model.Name);
+            if (existingRobot is not null)
+            {
+                return StatusCode((int)HttpStatusCode.BadRequest,
+                    new ApiResponse((int)HttpStatusCode.BadRequest,
+                        "Robot with specified name already exists"));
+            }
             model.OnboardedTime = model.LastUpdatedTime;
             var robot = await _robotRepository.AddAsync(model);
             if (robot is null)

--- a/src/RedisInterface/Controllers/TaskController.cs
+++ b/src/RedisInterface/Controllers/TaskController.cs
@@ -113,6 +113,13 @@ public class TaskController : ControllerBase
         try
         {
             var model = request.ToTask();
+            var existingTask = await _taskRepository.FindSingleAsync(t=>t.Name == model.Name);
+            if (existingTask is not null)
+            {
+                return StatusCode((int)HttpStatusCode.BadRequest,
+                    new ApiResponse((int)HttpStatusCode.BadRequest,
+                        "Task with specified name already exists"));
+            }
             var task = await _taskRepository.AddAsync(model);
             if (task is null)
             {
@@ -350,8 +357,15 @@ public class TaskController : ControllerBase
             return BadRequest(new ApiResponse((int)HttpStatusCode.BadRequest,
                 "This task ID has already been used, please specify a new Task ID."));
         }
+        var existingTask = await _taskRepository.FindSingleAsync(t=>t.Name == model.Name);
+        if (existingTask is not null)
+        {
+            return StatusCode((int)HttpStatusCode.BadRequest,
+                new ApiResponse((int)HttpStatusCode.BadRequest,
+                    "Task with specified name already exists"));
+        }
 
-        if (!model.ActionSequence.Any())
+        if (!model.ActionSequence!.Any())
         {
             return BadRequest(new ApiResponse((int)HttpStatusCode.BadRequest,
                 "Parameters for ActionSequence were not specified."));

--- a/src/RedisInterface/RedisInterface.csproj
+++ b/src/RedisInterface/RedisInterface.csproj
@@ -50,10 +50,6 @@
     <None Remove="LuaQueries\GetResourceCloudData.lua" />
     <None Remove="LuaQueries\GetResourceEdgeData.lua" />
     <None Remove="LuaQueries\GetSameFamilyAction.lua" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="Contracts" />
   </ItemGroup> 
 
 </Project>


### PR DESCRIPTION
# Description
When adding objects, we could add multiple ones with the same names. Added name check and returns `400` status code when an object with the specified name already exists. 

Fixes #268 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## What has been changed?
- Fix: checked for name duplications when adding a new object

# How Has This Been Tested?
- [x] Tried adding a new object with the name that is already in use

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes