### PR TITLE
fix: only matching locations are selected when looking for resource-based location

### DIFF
--- a/src/ResourcePlanner/Policies/LocationSelection/ResourceBasedLocation.cs
+++ b/src/ResourcePlanner/Policies/LocationSelection/ResourceBasedLocation.cs
@@ -107,9 +107,11 @@ internal class ResourceBasedLocation : ILocationSelectionPolicy
 
                 score += (int)latScore * (int)hwClaim.Latency.Priority;
             }
-
-            //location with the highest score must be the best
-            scores.Add(loc, score);
+            
+            if (score > 0)
+            {
+                scores.Add(loc, score);    
+            }
         }
 
         KeyValuePair<Location, int>? maxScore = null;
@@ -120,7 +122,6 @@ internal class ResourceBasedLocation : ILocationSelectionPolicy
         }
 
         if (maxScore is null) return null;
-
         FoundMatchingLocation = true;
         var finalLoc = maxScore.Value.Key;
         var hwSpec = new HardwareSpec

--- a/src/TaskPlanner/Controllers/PlanController.cs
+++ b/src/TaskPlanner/Controllers/PlanController.cs
@@ -72,7 +72,7 @@ public class PlanController : ControllerBase
             }
 
             if (dryRun)
-                return Ok(resourcePlan);
+                return Ok(resourcePlan.Task);
 
             await _publishService.PublishPlanAsync(resourcePlan.Task, robot2);
 


### PR DESCRIPTION
# Description

Fix Resource Based Location Selection Policy returning random location when no locations meet the requirements. Now, when no locations meet the requirements, the default location will be selected.

Fixes #267 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## What has been changed?

- Fix: when no locations matched the LocationSelection Policy, a random location was selected from the set.

# How Has This Been Tested?

- [X] when there are no matching locations, default location is returned when asking for the task plan
- [x] when there is matching location, it is returned
- [x] in case multiple location selection policies are applied, location is negotiated and returned

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes