### PR TITLE
198 subdomain based netapp routing

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -31,7 +31,7 @@ services:
       - Middleware__Organization=5G-ERA-DEV
       - Middleware__InstanceName=BB
       - Middleware__InstanceType=Edge
-      - Middleware__Address=localhost:5047
+      - Middleware__Address=http://localhost:5047
     ports:
       - "5036:80"
       - "7036:443"    
@@ -81,6 +81,7 @@ services:
       - Middleware__Organization=5G-ERA-DEV
       - Middleware__InstanceName=BB
       - Middleware__InstanceType=Edge
+      - Middleware__Address=http://localhost:5047 
     ports:
       - "5047:80"
       - "7047:443"    

--- a/src/Common/Config/RabbitMqConfig.cs
+++ b/src/Common/Config/RabbitMqConfig.cs
@@ -10,6 +10,11 @@ public class RabbitMqConfig
     /// RabbitMQ broker address
     /// </summary>
     public string Address { get; set; }
+
+    /// <summary>
+    /// Password
+    /// </summary>
+    public ushort? Port { get; set; }
     /// <summary>
     /// User
     /// </summary>

--- a/src/DataAccess/ExtensionMethods/DataAccessExtensionMethods.cs
+++ b/src/DataAccess/ExtensionMethods/DataAccessExtensionMethods.cs
@@ -30,7 +30,7 @@ public static class DataAccessExtensionMethods
         var config = builder.Configuration.GetSection(RedisConfig.ConfigName).Get<RedisConfig>();
 
         //For the redis-cluster master node, port 6380 should be used, using port 6379 will point to the replicas of the redis-cluster
-        var mux = ConnectionMultiplexer.Connect($"{config.ClusterHostname}:6379", c => c.Password = config.Password);
+        var mux = ConnectionMultiplexer.Connect($"{config.ClusterHostname}", c => c.Password = config.Password);
         IRedisConnectionProvider provider = new RedisConnectionProvider(mux);
         builder.Services.AddSingleton(provider);
         builder.Services.AddSingleton<IConnectionMultiplexer>(mux);

--- a/src/Models/Domain/BaseModel.cs
+++ b/src/Models/Domain/BaseModel.cs
@@ -16,7 +16,13 @@ public abstract class BaseModel
     protected string GetNetAppAddress(string netAppName, Uri address)
     {
         var sanitized = netAppName.SanitizeToUriPath();
-        return $"{address}/{sanitized}";
+        string protocol = address.Scheme;
+        string domain = address.Host;
+        int port = address.Port;
+
+        string modifiedAddress = $"{protocol}://{sanitized}.{domain}:{port}";
+
+        return modifiedAddress;
     }
 
     protected string GetNetAppReportAddress(Uri address)

--- a/src/Models/Domain/BaseModel.cs
+++ b/src/Models/Domain/BaseModel.cs
@@ -16,9 +16,9 @@ public abstract class BaseModel
     protected string GetNetAppAddress(string netAppName, Uri address)
     {
         var sanitized = netAppName.SanitizeToUriPath();
-        string protocol = address.Scheme;
-        string domain = address.Host;
-        int port = address.Port;
+        var protocol = address.IsAbsoluteUri ? address.Scheme : "http";
+        var domain = address.IsAbsoluteUri ? address.Host : address.ToString();
+        int port = address.IsAbsoluteUri ? address.Port : 80;
 
         string modifiedAddress = $"{protocol}://{sanitized}.{domain}:{port}";
 

--- a/src/OcelotGateway/Controllers/LoginController.cs
+++ b/src/OcelotGateway/Controllers/LoginController.cs
@@ -21,16 +21,14 @@ public class LoginController : MiddlewareController
     private readonly IOptions<JwtConfig> _jwtConfig;
     private readonly ILogger _logger;
     private readonly IUserRepository _userRepository;
-    private readonly GatewayConfigurationService _service;
 
 
     public LoginController(IUserRepository userRepository, IOptions<JwtConfig> jwtConfig,
-        ILogger<LoginController> logger, GatewayConfigurationService service)
+        ILogger<LoginController> logger)
     {
         _userRepository = userRepository ?? throw new ArgumentNullException(nameof(userRepository));
         _jwtConfig = jwtConfig ?? throw new ArgumentNullException(nameof(jwtConfig));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-        _service = service;
     }
 
 
@@ -133,14 +131,5 @@ public class LoginController : MiddlewareController
             _logger.LogError(ex, "An error has occured during the authentication process");
             return new(false, null);
         }
-    }
-
-    [AllowAnonymous]
-    [HttpPost]
-    [Route("route", Name = "Route")]
-
-    public async Task Route([FromBody]GatewayAddNetAppEntryMessage msg) 
-    {
-        _service.CreateDynamicRoute(msg);
     }
 }

--- a/src/OcelotGateway/Controllers/LoginController.cs
+++ b/src/OcelotGateway/Controllers/LoginController.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Options;
 using Middleware.Common;
 using Middleware.Common.Config;
 using Middleware.Common.Helpers;
+using Middleware.Common.MessageContracts;
 using Middleware.Common.Responses;
 using Middleware.DataAccess.Repositories.Abstract;
 using Middleware.Models.Domain;
@@ -20,14 +21,16 @@ public class LoginController : MiddlewareController
     private readonly IOptions<JwtConfig> _jwtConfig;
     private readonly ILogger _logger;
     private readonly IUserRepository _userRepository;
+    private readonly GatewayConfigurationService _service;
 
 
     public LoginController(IUserRepository userRepository, IOptions<JwtConfig> jwtConfig,
-        ILogger<LoginController> logger)
+        ILogger<LoginController> logger, GatewayConfigurationService service)
     {
         _userRepository = userRepository ?? throw new ArgumentNullException(nameof(userRepository));
         _jwtConfig = jwtConfig ?? throw new ArgumentNullException(nameof(jwtConfig));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _service = service;
     }
 
 
@@ -130,5 +133,14 @@ public class LoginController : MiddlewareController
             _logger.LogError(ex, "An error has occured during the authentication process");
             return new(false, null);
         }
+    }
+
+    [AllowAnonymous]
+    [HttpPost]
+    [Route("route", Name = "Route")]
+
+    public async Task Route([FromBody]GatewayAddNetAppEntryMessage msg) 
+    {
+        _service.CreateDynamicRoute(msg);
     }
 }

--- a/src/OcelotGateway/ExtensionMethods/ServiceCollectionExtensions.cs
+++ b/src/OcelotGateway/ExtensionMethods/ServiceCollectionExtensions.cs
@@ -25,7 +25,8 @@ public static class ServiceCollectionExtensions
 
             x.UsingRabbitMq((busRegistrationContext, mqBusFactoryConfigurator) =>
             {
-                mqBusFactoryConfigurator.Host(mqConfig.Address, "/", hostConfig =>
+                var port = mqConfig.Port ?? 5672;
+                mqBusFactoryConfigurator.Host(mqConfig.Address, port , "/", hostConfig =>
                 {
                     hostConfig.Username(mqConfig.User);
                     hostConfig.Password(mqConfig.Pass);

--- a/src/OcelotGateway/Program.cs
+++ b/src/OcelotGateway/Program.cs
@@ -31,6 +31,8 @@ builder.Services.DecorateClaimAuthoriser();
 
 var config = builder.Configuration.GetSection(JwtConfig.ConfigName).Get<JwtConfig>();
 builder.Services.Configure<JwtConfig>(builder.Configuration.GetSection(JwtConfig.ConfigName));
+//var mwConfig = builder.Configuration.GetSection(MiddlewareConfig.ConfigName).Get<MiddlewareConfig>();
+builder.Services.Configure<MiddlewareConfig>(builder.Configuration.GetSection(MiddlewareConfig.ConfigName));
 
 builder.Services.AddAuthentication(options =>
     {

--- a/src/OcelotGateway/Services/GatewayConfigurationService.cs
+++ b/src/OcelotGateway/Services/GatewayConfigurationService.cs
@@ -1,4 +1,5 @@
-﻿using System.Security.Policy;
+﻿using System.Data.SqlTypes;
+using System.Security.Policy;
 using System.Text;
 using MassTransit.Configuration;
 using Microsoft.Extensions.Options;
@@ -48,19 +49,22 @@ public class GatewayConfigurationService
             address);
         var path = msg.Route.SanitizeToUriPath();
         _logger.LogInformation("Opening new route with path: {path}", path);
-        string mwAddress = _mwConfig.Value.Address.Replace(":30009", "");
+        string mwAddress = _mwConfig.Value.Address.ToString();
+        //var mwAddress = "http://middleware.local";
         int position = 7;
         StringBuilder stringBuilder = new StringBuilder(mwAddress);
         stringBuilder.Insert(position, path+".");
         string newHost = stringBuilder.ToString();
+        Uri uri = new Uri(newHost);
+        var validHost = uri.Host;
         var routeCfg = new RouteConfig
         {
             RouteId = msg.NetAppName + "-Route",
             Match = new()
-            {
+            {                
                 //ros-object-detection.middleware.net
                 //Path = "/" + path + "/{**remainder}",
-                Hosts = new[] {newHost}            
+                Hosts = new[] { validHost }            
             },
             ClusterId = clusterCfg.ClusterId
         };

--- a/src/OcelotGateway/Services/GatewayConfigurationService.cs
+++ b/src/OcelotGateway/Services/GatewayConfigurationService.cs
@@ -64,21 +64,21 @@ public class GatewayConfigurationService
             },
             ClusterId = clusterCfg.ClusterId
         };
-        var routeSocketIoCfg = new RouteConfig
-        {
-            RouteId = msg.NetAppName + "SocketIO-Route",
-            Match = new()
-            {
-                Path = "/socket.io/{**remainder}"
-            },
-            ClusterId = clusterCfg.ClusterId //
-        };
+        // var routeSocketIoCfg = new RouteConfig
+        // {
+        //     RouteId = msg.NetAppName + "SocketIO-Route",
+        //     Match = new()
+        //     {
+        //         Path = "/socket.io/{**remainder}"
+        //     },
+        //     ClusterId = clusterCfg.ClusterId //
+        // };
         // transforms allow us to change the path that is requested like below to replace direct forwarding
-        routeCfg = routeCfg.WithTransformPathRemovePrefix($"/{msg.NetAppName}");
+        //routeCfg = routeCfg.WithTransformPathRemovePrefix($"/{msg.NetAppName}");
 
         clusterList.Add(clusterCfg);
         routeList.Add(routeCfg);
-        routeList.Add(routeSocketIoCfg);
+        //routeList.Add(routeSocketIoCfg);
 
         _inMemoryConfigProvider.Update(routeList, clusterList);
 

--- a/src/OcelotGateway/Services/GatewayConfigurationService.cs
+++ b/src/OcelotGateway/Services/GatewayConfigurationService.cs
@@ -48,7 +48,7 @@ public class GatewayConfigurationService
             address);
         var path = msg.Route.SanitizeToUriPath();
         _logger.LogInformation("Opening new route with path: {path}", path);
-        string mwAddress = _mwConfig.Value.Address;
+        string mwAddress = _mwConfig.Value.Address.Replace(":30009", "");
         int position = 7;
         StringBuilder stringBuilder = new StringBuilder(mwAddress);
         stringBuilder.Insert(position, path+".");

--- a/src/OcelotGateway/appsettings.json
+++ b/src/OcelotGateway/appsettings.json
@@ -6,7 +6,8 @@
   "RabbitMQ": {
     "Address": "",
     "User": "",
-    "Pass": ""
+    "Pass": "",
+    "Port": ""
   },
   "Middleware": {
     "Organization": "",

--- a/src/OcelotGateway/ocelot.Development.json
+++ b/src/OcelotGateway/ocelot.Development.json
@@ -25,18 +25,6 @@
       "UpstreamPathTemplate": "/Register",
       "UpstreamHttpMethod": [ "POST" ]
     },
-    {
-      "DownstreamPathTemplate": "/api/v1/route",
-      "DownstreamScheme": "http",
-      "DownstreamHostAndPorts": [
-        {
-          "Host": "ocelotgateway.api",
-          "Port": "80"
-        }
-      ],
-      "UpstreamPathTemplate": "/Route",
-      "UpstreamHttpMethod": [ "POST" ]
-    },
     //RedisInterface API
     {
       "DownstreamPathTemplate": "/api/v1/{all}",

--- a/src/OcelotGateway/ocelot.Development.json
+++ b/src/OcelotGateway/ocelot.Development.json
@@ -25,6 +25,18 @@
       "UpstreamPathTemplate": "/Register",
       "UpstreamHttpMethod": [ "POST" ]
     },
+    {
+      "DownstreamPathTemplate": "/api/v1/route",
+      "DownstreamScheme": "http",
+      "DownstreamHostAndPorts": [
+        {
+          "Host": "ocelotgateway.api",
+          "Port": "80"
+        }
+      ],
+      "UpstreamPathTemplate": "/Route",
+      "UpstreamHttpMethod": [ "POST" ]
+    },
     //RedisInterface API
     {
       "DownstreamPathTemplate": "/api/v1/{all}",

--- a/src/Orchestrator/Deployment/KubernetesObjectBuilder.cs
+++ b/src/Orchestrator/Deployment/KubernetesObjectBuilder.cs
@@ -228,6 +228,7 @@ internal class KubernetesObjectBuilder : IKubernetesObjectBuilder
             new("RabbitMQ__Address", _env.GetEnvVariable("RabbitMQ__Address")),
             new("RabbitMQ__User", _env.GetEnvVariable("RabbitMQ__User")),
             new("RabbitMQ__Pass", _env.GetEnvVariable("RabbitMQ__Pass")),
+            new("RabbitMQ__Port", _env.GetEnvVariable("RabbitMQ__Port")),
             new("CENTRAL_API_HOSTNAME", _env.GetEnvVariable("CENTRAL_API_HOSTNAME")),
             new("AWS_ACCESS_KEY_ID", _env.GetEnvVariable("AWS_ACCESS_KEY_ID")),
             new("AWS_SECRET_ACCESS_KEY", _env.GetEnvVariable("AWS_SECRET_ACCESS_KEY"))

--- a/src/Orchestrator/Deployment/KubernetesObjectBuilder.cs
+++ b/src/Orchestrator/Deployment/KubernetesObjectBuilder.cs
@@ -216,7 +216,7 @@ internal class KubernetesObjectBuilder : IKubernetesObjectBuilder
         };
         var envList = new List<V1EnvVar>
         {
-            new("Middleware__Organization", _mwConfig.Value.Organization),
+            new("Middleware__Address", _mwConfig.Value.Address),
             new("Middleware__Organization", _mwConfig.Value.Organization),
             new("Middleware__InstanceName", _mwConfig.Value.InstanceName),
             new("Middleware__InstanceType", _mwConfig.Value.InstanceType),

--- a/src/Orchestrator/Deployment/KubernetesObjectBuilder.cs
+++ b/src/Orchestrator/Deployment/KubernetesObjectBuilder.cs
@@ -327,7 +327,7 @@ internal class KubernetesObjectBuilder : IKubernetesObjectBuilder
 
             envVars.Add(new("NETAPP_ID", serviceInstanceId.ToString()));
             envVars.Add(new("NETAPP_NAME", name));
-            envVars.Add(new("MIDDLEWARE_ADDRESS", "http://" + thisLocation.GetNetAppStatusReportAddress()));
+            envVars.Add(new("MIDDLEWARE_ADDRESS", thisLocation.GetNetAppStatusReportAddress()));
             envVars.Add(new("MIDDLEWARE_REPORT_INTERVAL", ReportIntervalInSeconds.ToString()));
 
             container.Env = envVars;

--- a/src/Orchestrator/ExtensionMethods/ServiceCollectionExtensions.cs
+++ b/src/Orchestrator/ExtensionMethods/ServiceCollectionExtensions.cs
@@ -31,7 +31,8 @@ public static class ServiceCollectionExtensions
 
             x.UsingRabbitMq((busRegistrationContext, mqBusFactoryConfigurator) =>
             {
-                mqBusFactoryConfigurator.Host(mqConfig.Address, "/", hostConfig =>
+                var port  = mqConfig.Port ?? 5672;
+                mqBusFactoryConfigurator.Host(mqConfig.Address, port, "/", hostConfig =>
                 {
                     hostConfig.Username(mqConfig.User);
                     hostConfig.Password(mqConfig.Pass);

--- a/src/Orchestrator/appsettings.json
+++ b/src/Orchestrator/appsettings.json
@@ -9,7 +9,8 @@
   "RabbitMQ": {
     "Address": "",
     "User": "",
-    "Pass": ""
+    "Pass": "",
+    "Port": ""
   },
   "Redis": {
     "HostName": "Redis__HostName",

--- a/src/ResourcePlanner/ExtensionMethods/ServiceCollectionExtensions.cs
+++ b/src/ResourcePlanner/ExtensionMethods/ServiceCollectionExtensions.cs
@@ -20,7 +20,8 @@ public static class ServiceCollectionExtensions
 
             x.UsingRabbitMq((busRegistrationContext, mqBusFactoryConfigurator) =>
             {
-                mqBusFactoryConfigurator.Host(mqConfig.Address, "/", hostConfig =>
+                var port = mqConfig.Port ?? 5672;
+                mqBusFactoryConfigurator.Host(mqConfig.Address, port, "/", hostConfig =>
                 {
                     hostConfig.Username(mqConfig.User);
                     hostConfig.Password(mqConfig.Pass);

--- a/src/ResourcePlanner/appsettings.json
+++ b/src/ResourcePlanner/appsettings.json
@@ -2,7 +2,8 @@
   "RabbitMQ": {
     "Address": "",
     "User": "",
-    "Pass": ""
+    "Pass": "",
+    "Port": ""
   },
   "Slice": {
     "Hostname": ""

--- a/src/TaskPlanner/ExtensionMethods/ServiceCollectionExtensions.cs
+++ b/src/TaskPlanner/ExtensionMethods/ServiceCollectionExtensions.cs
@@ -15,7 +15,8 @@ public static class ServiceCollectionExtensions
         {
             x.UsingRabbitMq((busRegistrationContext, mqBusFactoryConfigurator) =>
             {
-                mqBusFactoryConfigurator.Host(mqConfig.Address, "/", hostConfig =>
+                var port = mqConfig.Port ?? 5672;
+                mqBusFactoryConfigurator.Host(mqConfig.Address, port, "/", hostConfig =>
                 {
                     hostConfig.Username(mqConfig.User);
                     hostConfig.Password(mqConfig.Pass);

--- a/src/TaskPlanner/appsettings.json
+++ b/src/TaskPlanner/appsettings.json
@@ -2,7 +2,8 @@
   "RabbitMQ": {
     "Address": "",
     "User": "",
-    "Pass": ""
+    "Pass": "",
+    "Port": ""
   },
   "Redis": {
     "HostName": "",

--- a/test/Orchestrator.Tests.Unit/Deployment/DeploymentServiceTests.cs
+++ b/test/Orchestrator.Tests.Unit/Deployment/DeploymentServiceTests.cs
@@ -35,7 +35,8 @@ public class DeploymentServiceTests
     {
         InstanceName = "test-MW",
         InstanceType = "Edge",
-        Organization = "5G-ERA-TST"
+        Organization = "5G-ERA-TST",
+        Address = "https://crop.5gera.net",
     });
 
     private readonly IPublishingService _publishingService = Substitute.For<IPublishingService>();

--- a/util/websocket_tester/.idea/workspace.xml
+++ b/util/websocket_tester/.idea/workspace.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AutoImportSettings">
+    <option name="autoReloadType" value="SELECTIVE" />
+  </component>
+  <component name="ChangeListManager">
+    <list default="true" id="44ab6093-1448-4e2b-9528-f5eea4b34ea4" name="Changes" comment="" />
+    <option name="SHOW_DIALOG" value="false" />
+    <option name="HIGHLIGHT_CONFLICTS" value="true" />
+    <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
+    <option name="LAST_RESOLUTION" value="IGNORE" />
+  </component>
+  <component name="HighlightingSettingsPerFile">
+    <setting file="file://$USER_HOME$/AppData/Local/JetBrains/PyCharm2023.1/remote_sources/-2033917913/-332473646/socketio/client.py" root0="SKIP_INSPECTION" />
+  </component>
+  <component name="ProjectColorInfo"><![CDATA[{
+  "associatedIndex": 0
+}]]></component>
+  <component name="ProjectId" id="2SQe2NIC1UvUSNtWWis0YVHhfwY" />
+  <component name="ProjectViewState">
+    <option name="hideEmptyMiddlePackages" value="true" />
+    <option name="showLibraryContents" value="true" />
+  </component>
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "Python.main.executor": "Run",
+    "RunOnceActivity.OpenProjectViewOnStart": "true",
+    "RunOnceActivity.ShowReadmeOnStart": "true",
+    "WebServerToolWindowFactoryState": "false",
+    "node.js.detected.package.eslint": "true",
+    "node.js.detected.package.tslint": "true",
+    "node.js.selected.package.eslint": "(autodetect)",
+    "node.js.selected.package.tslint": "(autodetect)",
+    "nodejs_package_manager_path": "npm",
+    "settings.editor.selected.configurable": "preferences.lookFeel",
+    "vue.rearranger.settings.migration": "true"
+  }
+}]]></component>
+  <component name="RunManager">
+    <configuration name="main" type="PythonConfigurationType" factoryName="Python" nameIsGenerated="true">
+      <module name="websocket" />
+      <option name="ENV_FILES" value="" />
+      <option name="INTERPRETER_OPTIONS" value="" />
+      <option name="PARENT_ENVS" value="true" />
+      <envs>
+        <env name="PYTHONUNBUFFERED" value="1" />
+      </envs>
+      <option name="SDK_HOME" value="" />
+      <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+      <option name="IS_MODULE_SDK" value="true" />
+      <option name="ADD_CONTENT_ROOTS" value="true" />
+      <option name="ADD_SOURCE_ROOTS" value="true" />
+      <EXTENSION ID="PythonCoverageRunConfigurationExtension" runner="coverage.py" />
+      <option name="SCRIPT_NAME" value="$PROJECT_DIR$/main.py" />
+      <option name="PARAMETERS" value="" />
+      <option name="SHOW_COMMAND_LINE" value="false" />
+      <option name="EMULATE_TERMINAL" value="false" />
+      <option name="MODULE_MODE" value="false" />
+      <option name="REDIRECT_INPUT" value="false" />
+      <option name="INPUT_FILE" value="" />
+      <method v="2" />
+    </configuration>
+  </component>
+  <component name="SharedIndexes">
+    <attachedChunks>
+      <set>
+        <option value="bundled-python-sdk-5a2391486177-2887949eec09-com.jetbrains.pycharm.pro.sharedIndexes.bundled-PY-233.13763.11" />
+      </set>
+    </attachedChunks>
+  </component>
+  <component name="SpellCheckerSettings" RuntimeDictionaries="0" Folders="0" CustomDictionaries="0" DefaultDictionary="application-level" UseSingleDictionary="true" transferred="true" />
+  <component name="TaskManager">
+    <task active="true" id="Default" summary="Default task">
+      <changelist id="44ab6093-1448-4e2b-9528-f5eea4b34ea4" name="Changes" comment="" />
+      <created>1689083023457</created>
+      <option name="number" value="Default" />
+      <option name="presentableId" value="Default" />
+      <updated>1689083023457</updated>
+      <workItem from="1689083030260" duration="2654000" />
+      <workItem from="1689145404496" duration="2437000" />
+      <workItem from="1689588263719" duration="2138000" />
+      <workItem from="1689597640195" duration="4078000" />
+      <workItem from="1689602772583" duration="366000" />
+      <workItem from="1689756078545" duration="5280000" />
+      <workItem from="1693824083439" duration="3000" />
+      <workItem from="1711023207191" duration="1384000" />
+    </task>
+    <servers />
+  </component>
+  <component name="TypeScriptGeneratedFilesManager">
+    <option name="version" value="3" />
+  </component>
+  <component name="com.intellij.coverage.CoverageDataManagerImpl">
+    <SUITE FILE_PATH="coverage/websocket$main.coverage" NAME="main Coverage Results" MODIFIED="1711024340326" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="coverage.py" COVERAGE_BY_TEST_ENABLED="true" COVERAGE_TRACING_ENABLED="false" WORKING_DIRECTORY="$PROJECT_DIR$" />
+  </component>
+</project>


### PR DESCRIPTION
# Description
The Middleware is now capable of routing traffic to multiple network applications simultaneously through the WebSocket protocol. The new routing mechanism is using subdomain names and enables independent connection with the network applications. The Middleware is not capable to host domains, therefore, the additional configuration of a CoreDns server has to be realised separately (documentation will be provided).

Within this branch, other minor fixes for deploying multiple Middleware instances have been addressed.

Fixes #198 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## What has been changed?

- Fix: Subdomain based network applications routing
- Fix: Minor fixes for multiple Middleware instances deployment

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test A - Routing to multiple network applications - successful
- [x] Test B - Multiple Middleware instances deployed with synchronised backing services under a single organisation - successful 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes