### PR TITLE
fix: labels in netapps with changed names

### DIFF
--- a/src/Orchestrator/Deployment/DeploymentService.cs
+++ b/src/Orchestrator/Deployment/DeploymentService.cs
@@ -344,7 +344,7 @@ internal class DeploymentService : IDeploymentService
             {
                 _logger.LogDebug("Deploying instance '{Name}', with serviceInstanceId '{ServiceInstanceId}'",
                     pair.Instance!.Name, pair.InstanceId);
-                await _kubernetesWrapper.DeployNetApp(pair);
+                retVal += await _kubernetesWrapper.DeployNetApp(pair);
 
                 if (ShouldDeployInterRelay(pair.Instance, item.Key) == false)
                 {
@@ -526,6 +526,7 @@ internal class DeploymentService : IDeploymentService
 
         if (builder is not null)
         {
+            
             var rosSpec = new RosSpec(instance.RosTopicsSub,
                 instance.RosTopicsPub,
                 instance.Services,

--- a/src/Orchestrator/Deployment/KubernetesObjectBuilder.cs
+++ b/src/Orchestrator/Deployment/KubernetesObjectBuilder.cs
@@ -327,7 +327,8 @@ internal class KubernetesObjectBuilder : IKubernetesObjectBuilder
         {
             obj.Spec.Selector.MatchLabels[key] = name.SanitizeAsK8sObjectName();
         }
-        
+
+        obj.Spec.Template.Metadata.Labels = obj.Spec.Selector.MatchLabels;
         obj.Metadata.SetServiceLabel(serviceInstanceId);
         obj.Metadata.Name = name.SanitizeAsK8sObjectName();
         foreach (var container in obj.Spec.Template.Spec.Containers)

--- a/src/Orchestrator/Deployment/KubernetesObjectBuilder.cs
+++ b/src/Orchestrator/Deployment/KubernetesObjectBuilder.cs
@@ -279,7 +279,7 @@ internal class KubernetesObjectBuilder : IKubernetesObjectBuilder
         var spec = new V1ServiceSpec
         {
             Ports = servicePorts,
-            Selector = depl.Metadata.Labels,
+            Selector = depl.Spec.Selector.MatchLabels,
             Type = K8SServiceKind.ClusterIp.GetStringValue()
         };
 

--- a/src/Orchestrator/Deployment/KubernetesWrapper.cs
+++ b/src/Orchestrator/Deployment/KubernetesWrapper.cs
@@ -40,6 +40,7 @@ public class KubernetesWrapper : IKubernetesWrapper
         }
         catch (HttpOperationException ex)
         {
+            _logger.LogError("Failed to deploy NetApp: {reason}", ex.Response.ReasonPhrase);
             return Result.Failure(ex.Response.ReasonPhrase);
         }
     }

--- a/test/Orchestrator.Tests.Unit/Deployment/DeploymentServiceTests.cs
+++ b/test/Orchestrator.Tests.Unit/Deployment/DeploymentServiceTests.cs
@@ -81,6 +81,7 @@ public class DeploymentServiceTests
         
         _systemConfigRepo.GetConfigAsync().Returns(systemConfig);
         _kubeWrapper.GetCurrentlyDeployedNetApps().Returns(currentlyRunningDeployments);
+        _kubeWrapper.DeployNetApp(Arg.Any<DeploymentPair>()).Returns(Result.Success());
         _redisInterface.GetLocationByNameAsync(_mwConfig.Value.InstanceName).Returns(location.ToLocationResponse());
         _redisInterface.RobotGetByIdAsync(robot.Id).Returns(robot.ToRobotResponse());
         


### PR DESCRIPTION
# Description

Fixed labels when Netapp is already deployed and the second instance is deployed with the changed names. 

Fixes #296 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## What has been changed?


- Fix: labels in the netapp with changed name



# How Has This Been Tested?
- [x] Deployed the netapp and now each client connects to their respective netapp

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes