### PR TITLE
docs: removed action server documentation in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,14 +38,6 @@ The image below presents the conceptual architecture of the 5G-ERA Middleware an
 
 The 5G-ERA Middleware connects to the Redis Cluster, which allows sharing of semantic knowledge between all the instances of the 5G-ERA Middleware running in every Cloud and Edge device.
 
-## Action Server
-
-The communication between the 5G-ERA Middleware and the robot is conducted using a ROS Action Client, Action Server as well as Service Calls. Both ROS 1 and ROS2 versions are available for the Action-Server/client.
-
-The action client and the robot itself are responsible for letting the middleware know via action server and microservices of the latest status of the action and NetApp. Two types of information are defined here: heartbeat and action status. The first one will be a request from the middleware with a specific frequency to measure the health of the deployed application/s that the currently executed action is using. The second one defines a high-level conceptualization of the status of the action. 
-
-For a more in-detail description of the Action Server see [ACTION_SERVER_README.md](ACTION_SERVER_README.md)
-
 ## Middleware API specification
 
 The 5G-ERA Middleware has an OpenAPI specification that can be checked under this [link](https://app.swaggerhub.com/apis/BARTOSZBRTATUS/5-g_era_middleware/0.1).


### PR DESCRIPTION
# Description

Removed documentation of action server from main readme to avoid confusion.
